### PR TITLE
feat(doctor): add am doctor readiness reporting

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -124,15 +124,21 @@ built-in integration required. Depends on the decoupling above.
 
 ### `am doctor` readiness check
 
-Add a command that reports what's present/missing for a first successful
-`am start`: repo + VCS, `.am/` initialized, container runtime, an available
-image, tmux, and (per selected integration) required credentials/paths. Reuses
-the existing preflight checks in `container.rs`. Preferred over silently
-auto-bootstrapping `.am/` on `am start`.
+**Done.** `src/doctor.rs` reports repo + VCS, `.am/` initialization, git identity, tmux,
+container runtime, environment source, and per-agent credentials — and in devcontainer
+mode the CLI and its version, Node ≥ 20, the discovered config, whether the built image
+is current for the config hash, and constructs `am` refuses (`dockerComposeFile`) or drops
+(`initializeCommand`, `runArgs`).
 
-Once dev container support lands, also report: devcontainer CLI present, Node ≥ 20,
-a discovered `.devcontainer/` config, whether its built image is current, and any
-unsupported (compose) or gated (`initializeCommand`, `privileged`) constructs.
+The checks call the same functions `cmd_start` does (`detect_runtime`,
+`validate_agent_credentials`, `devcontainer::find_config`), so a passing report and a
+working `am start` cannot drift apart. Exits 1 on any failure, so it gates a setup script;
+warnings alone do not fail. It mutates nothing, which is what makes it the alternative to
+auto-bootstrapping `.am/` as a side effect of `am start`.
+
+Not covered: `privileged` and `capAdd` are label-only properties, so they cannot be
+reported until the image has been built. Only the config-visible gated constructs
+(`initializeCommand`, `runArgs`) are checked.
 
 ### Session observability in `am list`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,13 @@ make build-copilot       # Build Copilot Docker image
 - `command.rs` — subprocess helpers (`run_command`, `run_built_command`, and output variants); shared stderr/status error formatting
 - `config.rs` — layered config: CLI flags → env vars → `.am/config.toml` → `~/.config/am/config.toml` → defaults
 - `error.rs` — `AmError` enum via `thiserror`; all functions return `anyhow::Result<T>`
+- `doctor.rs` — `am doctor` readiness checks; reuses `cmd_start`'s own preflight functions so a passing report and a working `am start` cannot drift apart
 - `devcontainer.rs` — Dev Container support: JSONC config parsing, `devcontainer.metadata` label parsing and merge, variable substitution, config hashing, `devcontainer build` delegation, trust gate
 - `session.rs` — session CRUD; state in `.am/sessions.json`
 - `worktree.rs` — git (`git worktree add`) and jj (`jj workspace add`) operations plus `WorktreeGuard` rollback; VCS detection (`find_repo_root`) is in `main.rs`
 - `tmux.rs` — tmux window/pane management
 - `container.rs` — Podman/Docker lifecycle; mount resolution; agent auth presets
-- `main.rs` — command handlers (`cmd_init`, `cmd_start`, `cmd_list`, `cmd_attach`, `cmd_run`, `cmd_destroy`, `cmd_generate_config`)
+- `main.rs` — command handlers (`cmd_init`, `cmd_start`, `cmd_list`, `cmd_attach`, `cmd_run`, `cmd_destroy`, `cmd_doctor`, `cmd_generate_config`)
 
 **VCS detection:** checks `.jj/` first, falls back to `.git`, errors if neither found.
 

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -157,6 +157,10 @@ unbounded work (`"context": ".."` means the whole repo), so if you edit a file y
 
 ## Troubleshooting
 
+Start with `am doctor`. It reports the discovered config, the CLI and its version, Node,
+whether the built image is current, and any construct `am` will refuse or drop — which
+covers most of what follows before you have to guess.
+
 **"devcontainer CLI not found"** — install `@devcontainers/cli` globally, point
 `devcontainer.cli` (or `AM_DEVCONTAINER_BIN`) at it, or switch to `container.mode = "image"`.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -28,6 +28,58 @@ Running `am init` in a directory that is not a git or jj repository is an error.
 
 ---
 
+## `am doctor`
+
+Report what is and is not ready for a successful `am start`, without changing anything.
+
+**Usage**
+
+```sh
+am doctor
+```
+
+**What it checks**
+
+| Section | Checks |
+|---|---|
+| Repository | Inside a git or jj repo |
+| Project setup | `.am/` initialized, git identity available |
+| tmux | Binary present, and whether you are currently inside a session |
+| Container runtime | Podman or Docker present (respects `container.runtime`) |
+| Environment | Where the environment comes from, and whether that source is usable |
+| Agent | Selected agent is known, and its credentials are present on this host |
+
+In dev container mode the Environment section additionally reports the discovered
+config, the `devcontainer` CLI and its version, Node 20+, whether the built image is
+current for the config hash, and any construct `am` will refuse (`dockerComposeFile`) or
+drop (`initializeCommand`, `runArgs`).
+
+**Output**
+
+Each check is `✓` (ready), `!` (usable, worth knowing), or `✗` (will stop `am start`),
+with the fix indented underneath:
+
+```
+Environment
+  ✓ source                 devcontainer at /path/to/.devcontainer/devcontainer.json
+  ✗ devcontainer CLI       'devcontainer' not found on PATH
+      → npm install -g @devcontainers/cli (needs Node 20+), or set container.mode = "image"
+  ✓ node                   v22.23.2 (>= 20 required)
+  ! built image            am-dc-f260010a69f5 not built yet
+      → the next 'am start' will build it — this can take a few minutes
+```
+
+**Exit code**
+
+`0` when nothing would stop `am start`, `1` otherwise. Warnings alone do not fail, so
+`am doctor && am start feat` is a usable setup gate.
+
+!!! note "Discovery uses your current checkout"
+    A session gets a fresh worktree off `HEAD`, so an *uncommitted* `devcontainer.json`
+    is not what that session will see. `am doctor` reports what is on disk now.
+
+---
+
 ## `am start <slug>`
 
 Create a new isolated agent session.

--- a/docs/reference/quick-reference.md
+++ b/docs/reference/quick-reference.md
@@ -9,6 +9,7 @@ One-page guide to common `am` commands, workflows, and configurations.
 | Command | Purpose |
 |---------|---------|
 | `am init` | Initialize am in current repo |
+| `am doctor` | Report what is/isn't ready for `am start` |
 | `am start <slug>` | Create a new agent session |
 | `am list` | Show all active sessions |
 | `am attach <slug>` | Switch to existing session |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,6 +56,9 @@ pub enum Commands {
         rebuild: bool,
     },
 
+    /// Report what is and is not ready for a successful `am start`
+    Doctor,
+
     /// List all sessions
     List,
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,831 @@
+//! `am doctor` — report what is and is not ready for a successful `am start`.
+//!
+//! Every check answers one question a user would otherwise answer by running `am start`
+//! and reading a failure. The checks deliberately reuse the same functions `cmd_start`
+//! calls (`detect_runtime`, `validate_agent_credentials`, `devcontainer::find_config`),
+//! so a passing report and a working `am start` cannot drift apart.
+//!
+//! Nothing here mutates anything. `am doctor` is safe to run at any time, which is the
+//! point: it is the alternative to `am start` silently bootstrapping state as a side
+//! effect of being run.
+
+use std::path::Path;
+
+use crate::config::{Config, ContainerMode, Vcs};
+use crate::{config, container, devcontainer, tmux};
+
+// ── Report types ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// Ready.
+    Ok,
+    /// Usable, but something is worth knowing.
+    Warn,
+    /// `am start` will not succeed in this configuration.
+    Fail,
+}
+
+impl Status {
+    fn glyph(self) -> &'static str {
+        match self {
+            Status::Ok => "✓",
+            Status::Warn => "!",
+            Status::Fail => "✗",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Check {
+    pub section: &'static str,
+    pub name: String,
+    pub status: Status,
+    pub detail: String,
+    /// What to do about it. Only meaningful for `Warn` and `Fail`.
+    pub hint: Option<String>,
+}
+
+impl Check {
+    fn new(section: &'static str, name: impl Into<String>, status: Status, detail: impl Into<String>) -> Self {
+        Self {
+            section,
+            name: name.into(),
+            status,
+            detail: detail.into(),
+            hint: None,
+        }
+    }
+
+    fn ok(section: &'static str, name: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self::new(section, name, Status::Ok, detail)
+    }
+
+    fn warn(
+        section: &'static str,
+        name: impl Into<String>,
+        detail: impl Into<String>,
+        hint: impl Into<String>,
+    ) -> Self {
+        Self::new(section, name, Status::Warn, detail).with_hint(hint)
+    }
+
+    fn fail(
+        section: &'static str,
+        name: impl Into<String>,
+        detail: impl Into<String>,
+        hint: impl Into<String>,
+    ) -> Self {
+        Self::new(section, name, Status::Fail, detail).with_hint(hint)
+    }
+
+    fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Report {
+    pub checks: Vec<Check>,
+}
+
+impl Report {
+    pub fn failures(&self) -> usize {
+        self.checks
+            .iter()
+            .filter(|c| c.status == Status::Fail)
+            .count()
+    }
+
+    pub fn warnings(&self) -> usize {
+        self.checks
+            .iter()
+            .filter(|c| c.status == Status::Warn)
+            .count()
+    }
+
+    /// Render for a terminal, grouped by section in the order the checks were added.
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        let mut current_section: Option<&str> = None;
+        for check in &self.checks {
+            if current_section != Some(check.section) {
+                if current_section.is_some() {
+                    out.push('\n');
+                }
+                out.push_str(check.section);
+                out.push('\n');
+                current_section = Some(check.section);
+            }
+            out.push_str(&format!(
+                "  {} {:<22} {}\n",
+                check.status.glyph(),
+                check.name,
+                check.detail
+            ));
+            if let Some(ref hint) = check.hint {
+                // Indented under the check it belongs to, so a wall of hints cannot be
+                // mistaken for a list of separate problems.
+                out.push_str(&format!("      → {hint}\n"));
+            }
+        }
+
+        let (failures, warnings) = (self.failures(), self.warnings());
+        out.push('\n');
+        if failures > 0 {
+            let noun = if failures == 1 { "problem" } else { "problems" };
+            out.push_str(&format!(
+                "{failures} {noun} will prevent 'am start' from working.\n"
+            ));
+        } else if warnings > 0 {
+            out.push_str("Ready. Some notes above are worth reading.\n");
+        } else {
+            out.push_str("Ready.\n");
+        }
+        out
+    }
+}
+
+// ── Checks ────────────────────────────────────────────────────────────────────
+
+const REPO: &str = "Repository";
+const PROJECT: &str = "Project setup";
+const TMUX: &str = "tmux";
+const RUNTIME: &str = "Container runtime";
+const ENVIRONMENT: &str = "Environment";
+const AGENT: &str = "Agent";
+
+/// Build the full report.
+///
+/// `repo` is `None` when the current directory is not inside a repository; that is a
+/// finding to report rather than an error to return, since it is one of the things a user
+/// runs `doctor` to discover.
+pub fn run(repo: Option<(&Path, Vcs)>, agent_flag: Option<&str>) -> Report {
+    let mut report = Report::default();
+
+    let repo_root = check_repository(&mut report, repo);
+    let cfg = load_config(repo_root);
+
+    if let Some(root) = repo_root {
+        check_project_setup(&mut report, root, &cfg);
+    }
+    check_tmux(&mut report);
+
+    let runtime = check_runtime(&mut report, &cfg);
+    let agent_name = effective_agent(agent_flag, &cfg);
+
+    if let Some(root) = repo_root {
+        check_environment(&mut report, root, &cfg, runtime.as_ref(), agent_name.as_deref());
+    }
+    check_agent(&mut report, agent_name.as_deref());
+
+    report
+}
+
+/// Load config the same way `cmd_start` does, falling back to global-only outside a repo.
+fn load_config(repo_root: Option<&Path>) -> Config {
+    let project = repo_root.map(|r| r.join(".am").join("config.toml"));
+    config::load_with_global(config::global_config_path().as_deref(), project.as_deref())
+        .unwrap_or_default()
+}
+
+fn effective_agent(agent_flag: Option<&str>, cfg: &Config) -> Option<String> {
+    agent_flag
+        .map(str::to_string)
+        .or_else(|| cfg.container.agent.clone())
+        .or_else(|| cfg.agent.clone())
+}
+
+fn check_repository<'a>(report: &mut Report, repo: Option<(&'a Path, Vcs)>) -> Option<&'a Path> {
+    match repo {
+        Some((root, vcs)) => {
+            let kind = match vcs {
+                Vcs::Git => "git",
+                Vcs::Jj => "jj",
+            };
+            report.checks.push(Check::ok(
+                REPO,
+                "version control",
+                format!("{kind} repository at {}", root.display()),
+            ));
+            Some(root)
+        }
+        None => {
+            report.checks.push(Check::fail(
+                REPO,
+                "version control",
+                "not inside a git or jj repository",
+                "run 'am' from inside a repository, or create one with 'git init'",
+            ));
+            None
+        }
+    }
+}
+
+fn check_project_setup(report: &mut Report, repo_root: &Path, cfg: &Config) {
+    let am_dir = repo_root.join(".am");
+    if !am_dir.is_dir() {
+        report.checks.push(Check::fail(
+            PROJECT,
+            ".am/",
+            "not initialized",
+            "run 'am init'",
+        ));
+        return;
+    }
+    report.checks.push(Check::ok(
+        PROJECT,
+        ".am/",
+        format!("initialized at {}", am_dir.display()),
+    ));
+
+    // cmd_start requires a gitconfig when containers are on, unless one is configured
+    // elsewhere — mirror that condition exactly rather than always demanding the file.
+    let gitconfig = cfg
+        .container
+        .gitconfig
+        .clone()
+        .unwrap_or_else(|| am_dir.join("gitconfig"));
+    if gitconfig.exists() {
+        report.checks.push(Check::ok(
+            PROJECT,
+            "git identity",
+            format!("{}", gitconfig.display()),
+        ));
+    } else if cfg.container.enabled {
+        report.checks.push(Check::fail(
+            PROJECT,
+            "git identity",
+            format!("{} not found", gitconfig.display()),
+            "run 'am init', or set container.gitconfig to an existing file",
+        ));
+    } else {
+        report.checks.push(Check::warn(
+            PROJECT,
+            "git identity",
+            format!("{} not found", gitconfig.display()),
+            "not required while container.enabled = false",
+        ));
+    }
+}
+
+fn check_tmux(report: &mut Report) {
+    match tmux::find_tmux() {
+        Some(path) => {
+            let detail = if tmux::is_in_tmux() {
+                format!("{} (currently inside a session)", path.display())
+            } else {
+                format!("{} (not currently inside a session)", path.display())
+            };
+            report.checks.push(Check::ok(TMUX, "tmux", detail));
+        }
+        None => report.checks.push(Check::warn(
+            TMUX,
+            "tmux",
+            "not found on PATH",
+            "'am start' still works — it runs the container directly instead of opening \
+             a window. Install tmux for the split-pane workflow.",
+        )),
+    }
+}
+
+fn check_runtime(report: &mut Report, cfg: &Config) -> Option<container::ContainerRuntime> {
+    if !cfg.container.enabled {
+        report.checks.push(Check::warn(
+            RUNTIME,
+            "containers",
+            "disabled (container.enabled = false)",
+            "sessions run directly on the host with no isolation",
+        ));
+        return None;
+    }
+    match container::detect_runtime(cfg.container.runtime.clone()) {
+        Ok(runtime) => {
+            report.checks.push(Check::ok(
+                RUNTIME,
+                "runtime",
+                format!("{} at {}", runtime.kind, runtime.bin.display()),
+            ));
+            Some(runtime)
+        }
+        Err(e) => {
+            report.checks.push(Check::fail(
+                RUNTIME,
+                "runtime",
+                e.to_string(),
+                "install Podman or Docker, or set container.enabled = false",
+            ));
+            None
+        }
+    }
+}
+
+/// Where the environment comes from, and whether that source is usable.
+fn check_environment(
+    report: &mut Report,
+    repo_root: &Path,
+    cfg: &Config,
+    runtime: Option<&container::ContainerRuntime>,
+    agent_name: Option<&str>,
+) {
+    if !cfg.container.enabled {
+        return;
+    }
+
+    // Discovery runs against the current checkout. A session gets a fresh worktree off
+    // HEAD, so an uncommitted config is not what the session will see — worth saying,
+    // because it is a genuinely confusing way to lose ten minutes.
+    let discovered = match cfg.container.mode {
+        ContainerMode::Image => None,
+        _ => match devcontainer::find_config(repo_root, cfg.devcontainer.path.as_deref()) {
+            Ok(found) => found,
+            Err(e) => {
+                report.checks.push(Check::fail(
+                    ENVIRONMENT,
+                    "devcontainer config",
+                    e.to_string(),
+                    "set devcontainer.path to choose one",
+                ));
+                return;
+            }
+        },
+    };
+
+    match (&cfg.container.mode, discovered) {
+        (ContainerMode::Image, _) => {
+            report.checks.push(Check::ok(
+                ENVIRONMENT,
+                "source",
+                "am-managed image (container.mode = \"image\")",
+            ));
+            check_image_mode(report, cfg, agent_name);
+        }
+        (ContainerMode::Devcontainer, None) => report.checks.push(Check::fail(
+            ENVIRONMENT,
+            "source",
+            "container.mode is \"devcontainer\" but no devcontainer.json was found",
+            "add .devcontainer/devcontainer.json, set devcontainer.path, or use \
+             container.mode = \"auto\"",
+        )),
+        (_, None) => {
+            report.checks.push(Check::ok(
+                ENVIRONMENT,
+                "source",
+                "am-managed image (no devcontainer.json found)",
+            ));
+            check_image_mode(report, cfg, agent_name);
+        }
+        (_, Some(path)) => {
+            report.checks.push(Check::ok(
+                ENVIRONMENT,
+                "source",
+                format!("devcontainer at {}", path.display()),
+            ));
+            check_devcontainer_mode(report, cfg, runtime, agent_name, &path);
+        }
+    }
+}
+
+fn check_image_mode(report: &mut Report, cfg: &Config, agent_name: Option<&str>) {
+    match config::resolve_image(agent_name, cfg) {
+        Some(image) => report
+            .checks
+            .push(Check::ok(ENVIRONMENT, "image", image.to_string())),
+        None => report.checks.push(Check::fail(
+            ENVIRONMENT,
+            "image",
+            "no image configured for the selected agent",
+            "set an agent with --agent or defaults.agent, or set container.image",
+        )),
+    }
+}
+
+fn check_devcontainer_mode(
+    report: &mut Report,
+    cfg: &Config,
+    runtime: Option<&container::ContainerRuntime>,
+    agent_name: Option<&str>,
+    config_path: &Path,
+) {
+    // The CLI is only needed to *build*. An already-built image means a session can start
+    // without it, so a missing CLI is not automatically fatal.
+    let cli = devcontainer::find_cli(&cfg.devcontainer.cli);
+    match &cli {
+        Ok(path) => {
+            let version = probe_version(path, "--version").unwrap_or_else(|| "unknown".to_string());
+            report.checks.push(Check::ok(
+                ENVIRONMENT,
+                "devcontainer CLI",
+                format!("{version} at {}", path.display()),
+            ));
+        }
+        Err(_) => report.checks.push(Check::fail(
+            ENVIRONMENT,
+            "devcontainer CLI",
+            format!("'{}' not found on PATH", cfg.devcontainer.cli),
+            "npm install -g @devcontainers/cli (needs Node 20+), or set \
+             container.mode = \"image\"",
+        )),
+    }
+
+    check_node(report, cli.is_ok());
+
+    let json = match devcontainer::parse_config(config_path) {
+        Ok(json) => json,
+        Err(e) => {
+            report.checks.push(Check::fail(
+                ENVIRONMENT,
+                "config",
+                e.to_string(),
+                "fix the JSON, then re-run 'am doctor'",
+            ));
+            return;
+        }
+    };
+
+    if let Err(e) = devcontainer::check_supported(&json) {
+        report.checks.push(Check::fail(
+            ENVIRONMENT,
+            "unsupported",
+            first_line(&e.to_string()),
+            "set container.mode = \"image\" to use an am-managed image instead",
+        ));
+    }
+
+    check_gated_constructs(report, cfg, &json);
+
+    // Image currency. The name is derived from the config hash, so "present" and
+    // "current" are the same question.
+    let injected = injected_features(cfg, agent_name);
+    match (devcontainer::image_name(config_path, &injected), runtime) {
+        (Ok(image), Some(runtime)) => {
+            if devcontainer::image_exists(&runtime.bin, &image) {
+                report.checks.push(Check::ok(
+                    ENVIRONMENT,
+                    "built image",
+                    format!("{image} (current)"),
+                ));
+            } else {
+                report.checks.push(Check::warn(
+                    ENVIRONMENT,
+                    "built image",
+                    format!("{image} not built yet"),
+                    "the next 'am start' will build it — this can take a few minutes",
+                ));
+            }
+        }
+        (Ok(image), None) => report.checks.push(Check::warn(
+            ENVIRONMENT,
+            "built image",
+            format!("{image} (cannot check without a container runtime)"),
+            "resolve the container runtime problem above",
+        )),
+        (Err(e), _) => report.checks.push(Check::fail(
+            ENVIRONMENT,
+            "built image",
+            e.to_string(),
+            "check that the config and any referenced Dockerfile are readable",
+        )),
+    }
+}
+
+/// Node is only required to *build*; report accordingly.
+fn check_node(report: &mut Report, cli_present: bool) {
+    const MIN_MAJOR: u32 = 20;
+    match probe_version(Path::new("node"), "--version").and_then(|v| node_major(&v).map(|m| (v, m)))
+    {
+        Some((version, major)) if major >= MIN_MAJOR => report.checks.push(Check::ok(
+            ENVIRONMENT,
+            "node",
+            format!("{version} (>= {MIN_MAJOR} required)"),
+        )),
+        Some((version, _)) => report.checks.push(Check::fail(
+            ENVIRONMENT,
+            "node",
+            format!("{version} is too old — the devcontainer CLI needs {MIN_MAJOR} or newer"),
+            "upgrade Node, or set container.mode = \"image\"",
+        )),
+        None if cli_present => report.checks.push(Check::warn(
+            ENVIRONMENT,
+            "node",
+            "not found on PATH",
+            "the devcontainer CLI needs Node — if it is bundled with its own runtime this \
+             is fine, otherwise install Node 20+",
+        )),
+        None => report.checks.push(Check::warn(
+            ENVIRONMENT,
+            "node",
+            "not found on PATH",
+            "install Node 20+ to build devcontainer images",
+        )),
+    }
+}
+
+/// Constructs `am` will refuse or drop unless explicitly allowed.
+fn check_gated_constructs(report: &mut Report, cfg: &Config, json: &devcontainer::DevcontainerJson) {
+    if cfg.devcontainer.allow_host_commands {
+        // Everything below is permitted; say so once rather than per-construct.
+        if json.initialize_command.is_some() || !json.run_args.is_empty() {
+            report.checks.push(Check::warn(
+                ENVIRONMENT,
+                "host commands",
+                "allowed (devcontainer.allow_host_commands = true)",
+                "initializeCommand runs on your host, outside the container",
+            ));
+        }
+        return;
+    }
+
+    if json.initialize_command.is_some() {
+        report.checks.push(Check::fail(
+            ENVIRONMENT,
+            "initializeCommand",
+            "present — it runs on your host, so am refuses it",
+            "read the command, then set devcontainer.allow_host_commands = true to allow it",
+        ));
+    }
+    if !json.run_args.is_empty() {
+        report.checks.push(Check::warn(
+            ENVIRONMENT,
+            "runArgs",
+            format!("{} will be ignored", json.run_args.join(" ")),
+            "set devcontainer.allow_host_commands = true to apply them",
+        ));
+    }
+}
+
+/// Mirrors `main::injected_features` so the hash — and therefore the image name — matches
+/// what `am start` would compute.
+fn injected_features(cfg: &Config, agent_name: Option<&str>) -> Vec<devcontainer::InjectedFeature> {
+    let mut features: Vec<devcontainer::InjectedFeature> = cfg
+        .devcontainer
+        .extra_features
+        .iter()
+        .map(|(id, options)| devcontainer::InjectedFeature::new(id, options))
+        .collect();
+    let wants_feature = matches!(
+        cfg.devcontainer.agent_install,
+        config::AgentInstall::Feature | config::AgentInstall::Auto
+    );
+    if wants_feature {
+        if let Some(feature) = config::resolve_agent_feature(agent_name, cfg) {
+            features.push(devcontainer::InjectedFeature::with_defaults(feature));
+        }
+    }
+    features.sort();
+    features.dedup();
+    features
+}
+
+fn check_agent(report: &mut Report, agent_name: Option<&str>) {
+    let Some(name) = agent_name else {
+        report.checks.push(Check::warn(
+            AGENT,
+            "agent",
+            "none configured",
+            "set defaults.agent in config, or pass --agent to 'am start'",
+        ));
+        return;
+    };
+
+    let agent = match container::KnownAgent::parse(name) {
+        Ok(agent) => agent,
+        Err(e) => {
+            report.checks.push(Check::fail(
+                AGENT,
+                "agent",
+                e.to_string(),
+                "pick one of: claude, copilot, gemini, codex",
+            ));
+            return;
+        }
+    };
+    report
+        .checks
+        .push(Check::ok(AGENT, "agent", agent.to_string()));
+
+    match container::validate_agent_credentials(agent) {
+        Ok(()) => report
+            .checks
+            .push(Check::ok(AGENT, "credentials", "present")),
+        Err(e) => report.checks.push(Check::fail(
+            AGENT,
+            "credentials",
+            first_line(&e.to_string()),
+            format!("authenticate {agent} on this machine, then re-run 'am doctor'"),
+        )),
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Run `<bin> <flag>` and return the first line of stdout, or `None` if it cannot run.
+fn probe_version(bin: &Path, flag: &str) -> Option<String> {
+    let output = std::process::Command::new(bin).arg(flag).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    text.lines().next().map(|l| l.trim().to_string())
+}
+
+/// Parse the major version out of Node's `v22.23.2`.
+fn node_major(version: &str) -> Option<u32> {
+    version
+        .trim()
+        .trim_start_matches('v')
+        .split('.')
+        .next()?
+        .parse()
+        .ok()
+}
+
+/// Multi-line errors carry a message and a hint; the report has its own hint column.
+fn first_line(text: &str) -> String {
+    text.lines().next().unwrap_or(text).trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn find(report: &Report, name: &str) -> Check {
+        report
+            .checks
+            .iter()
+            .find(|c| c.name == name)
+            .unwrap_or_else(|| panic!("no check named {name:?} in {:?}", names(report)))
+            .clone()
+    }
+
+    fn names(report: &Report) -> Vec<String> {
+        report.checks.iter().map(|c| c.name.clone()).collect()
+    }
+
+    fn has(report: &Report, name: &str) -> bool {
+        report.checks.iter().any(|c| c.name == name)
+    }
+
+    // ── Report shape ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn failures_and_warnings_are_counted_separately() {
+        let report = Report {
+            checks: vec![
+                Check::ok("S", "a", "fine"),
+                Check::warn("S", "b", "hmm", "do this"),
+                Check::fail("S", "c", "broken", "fix this"),
+                Check::fail("S", "d", "broken", "fix this"),
+            ],
+        };
+        assert_eq!(report.failures(), 2);
+        assert_eq!(report.warnings(), 1);
+    }
+
+    #[test]
+    fn render_groups_checks_under_their_section() {
+        let report = Report {
+            checks: vec![
+                Check::ok("First", "a", "detail-a"),
+                Check::ok("First", "b", "detail-b"),
+                Check::ok("Second", "c", "detail-c"),
+            ],
+        };
+        let out = report.render();
+        assert_eq!(out.matches("First").count(), 1, "section repeated: {out}");
+        assert!(out.find("First").unwrap() < out.find("Second").unwrap());
+    }
+
+    #[test]
+    fn render_includes_hints_only_where_present() {
+        let report = Report {
+            checks: vec![
+                Check::ok("S", "fine", "all good"),
+                Check::fail("S", "broken", "nope", "run 'am init'"),
+            ],
+        };
+        let out = report.render();
+        assert!(out.contains("→ run 'am init'"));
+        assert_eq!(out.matches('→').count(), 1);
+    }
+
+    #[test]
+    fn render_summarises_readiness() {
+        let ready = Report {
+            checks: vec![Check::ok("S", "a", "fine")],
+        };
+        assert!(ready.render().ends_with("Ready.\n"));
+
+        let noted = Report {
+            checks: vec![Check::warn("S", "a", "hmm", "note")],
+        };
+        assert!(noted.render().contains("worth reading"));
+
+        let broken = Report {
+            checks: vec![Check::fail("S", "a", "no", "fix")],
+        };
+        assert!(broken.render().contains("prevent 'am start'"));
+    }
+
+    // ── Repository ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn missing_repository_is_a_failure_not_an_error() {
+        // Being outside a repo is one of the things doctor exists to tell you.
+        let report = run(None, None);
+        let check = find(&report, "version control");
+        assert_eq!(check.status, Status::Fail);
+        assert!(check.detail.contains("not inside a git or jj repository"));
+    }
+
+    #[test]
+    fn outside_a_repo_skips_the_repo_specific_checks() {
+        let report = run(None, None);
+        assert!(!has(&report, ".am/"));
+        assert!(!has(&report, "source"));
+    }
+
+    #[test]
+    fn a_git_repo_is_reported_with_its_path() {
+        let tmp = TempDir::new().unwrap();
+        let report = run(Some((tmp.path(), Vcs::Git)), None);
+        let check = find(&report, "version control");
+        assert_eq!(check.status, Status::Ok);
+        assert!(check.detail.starts_with("git repository at"));
+    }
+
+    #[test]
+    fn a_jj_repo_is_reported_as_jj() {
+        let tmp = TempDir::new().unwrap();
+        let report = run(Some((tmp.path(), Vcs::Jj)), None);
+        assert!(find(&report, "version control").detail.starts_with("jj"));
+    }
+
+    // ── Project setup ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn uninitialised_project_points_at_am_init() {
+        let tmp = TempDir::new().unwrap();
+        let report = run(Some((tmp.path(), Vcs::Git)), None);
+        let check = find(&report, ".am/");
+        assert_eq!(check.status, Status::Fail);
+        assert_eq!(check.hint.as_deref(), Some("run 'am init'"));
+    }
+
+    #[test]
+    fn initialised_project_reports_ok() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".am")).unwrap();
+        std::fs::write(tmp.path().join(".am").join("gitconfig"), "").unwrap();
+        let report = run(Some((tmp.path(), Vcs::Git)), None);
+        assert_eq!(find(&report, ".am/").status, Status::Ok);
+        assert_eq!(find(&report, "git identity").status, Status::Ok);
+    }
+
+    #[test]
+    fn missing_gitconfig_fails_only_because_containers_need_it() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".am")).unwrap();
+        let report = run(Some((tmp.path(), Vcs::Git)), None);
+        let check = find(&report, "git identity");
+        assert_eq!(check.status, Status::Fail);
+        assert!(check.hint.as_deref().unwrap().contains("am init"));
+    }
+
+    // ── Agent ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn unknown_agent_is_rejected_with_the_valid_names() {
+        let tmp = TempDir::new().unwrap();
+        let report = run(Some((tmp.path(), Vcs::Git)), Some("not-an-agent"));
+        let check = find(&report, "agent");
+        assert_eq!(check.status, Status::Fail);
+        assert!(check.hint.as_deref().unwrap().contains("claude"));
+    }
+
+    #[test]
+    fn a_known_agent_is_reported_by_name() {
+        let tmp = TempDir::new().unwrap();
+        let report = run(Some((tmp.path(), Vcs::Git)), Some("claude"));
+        let check = find(&report, "agent");
+        assert_eq!(check.status, Status::Ok);
+        assert_eq!(check.detail, "claude");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn node_major_parses_the_v_prefixed_form() {
+        assert_eq!(node_major("v22.23.2"), Some(22));
+        assert_eq!(node_major("20.1.0"), Some(20));
+        assert_eq!(node_major("not a version"), None);
+    }
+
+    #[test]
+    fn first_line_drops_the_hint_half_of_an_error() {
+        assert_eq!(first_line("something failed\nHint: try this"), "something failed");
+        assert_eq!(first_line("single line"), "single line");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod command;
 mod config;
 mod container;
 mod devcontainer;
+mod doctor;
 mod error;
 mod messages;
 mod session;
@@ -43,6 +44,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         Commands::Attach { slug } => cmd_attach(&slug),
         Commands::Run { slug, agent } => cmd_run(&slug, &agent),
         Commands::Destroy { slug, force } => cmd_destroy(&slug, force, &msgs),
+        Commands::Doctor => cmd_doctor(None),
         Commands::GenerateConfig => cmd_generate_config(),
     }
 }
@@ -789,6 +791,25 @@ fn cmd_destroy(slug: &str, force: bool, msgs: &messages::Messages) -> anyhow::Re
     session::remove_session(&repo_root, slug)?;
 
     println!("Destroyed session '{slug}'.");
+    Ok(())
+}
+
+// ── am doctor ─────────────────────────────────────────────────────────────────
+
+/// Report readiness without changing anything.
+///
+/// Exits non-zero when something would stop `am start` from working, so it is usable as a
+/// setup gate in a script. Warnings alone do not fail.
+fn cmd_doctor(agent_flag: Option<&str>) -> anyhow::Result<()> {
+    let repo = find_repo_root().ok();
+    let report = doctor::run(
+        repo.as_ref().map(|(root, vcs)| (root.as_path(), vcs.clone())),
+        agent_flag,
+    );
+    print!("{}", report.render());
+    if report.failures() > 0 {
+        std::process::exit(1);
+    }
     Ok(())
 }
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -33,6 +33,14 @@ fn tmux_bin() -> Result<PathBuf> {
         .map_err(|_| AmError::TmuxError("tmux not found on PATH".to_string()).into())
 }
 
+/// Locate tmux without requiring it, for readiness reporting.
+///
+/// `am` works outside tmux — it launches the container directly — so callers that
+/// only want to *know* whether tmux is available should not have to handle an error.
+pub fn find_tmux() -> Option<PathBuf> {
+    tmux_bin().ok()
+}
+
 fn run_tmux(bin: &Path, args: &[&str]) -> Result<()> {
     command::run_command(&bin.to_string_lossy(), args, AmError::TmuxError)
 }

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -190,7 +190,14 @@ impl AmWorld {
         fs::write(
             &bin,
             format!(
+                // --version is answered before anything else and is not logged: `am
+                // doctor` probes it, and treating a probe as a build would both create
+                // the built-image marker and inflate the call count.
                 "#!/bin/sh\n\
+                 if [ \"$1\" = \"--version\" ]; then\n\
+                     echo '0.88.0'\n\
+                     exit 0\n\
+                 fi\n\
                  if [ -n \"$MOCK_DEVCONTAINER_LOG\" ]; then\n\
                      echo \"$@\" >> \"$MOCK_DEVCONTAINER_LOG\"\n\
                  fi\n{body}"
@@ -560,6 +567,12 @@ async fn then_session_not_contain(world: &mut AmWorld, slug: String) {
 async fn then_file_exists(world: &mut AmWorld, rel_path: String) {
     let path = world.project_path().join(&rel_path);
     assert!(path.exists(), "expected file at {path:?} to exist");
+}
+
+#[then(expr = "the file {string} does not exist")]
+async fn then_file_absent(world: &mut AmWorld, rel_path: String) {
+    let path = world.project_path().join(&rel_path);
+    assert!(!path.exists(), "expected no file at {path:?}");
 }
 
 #[then(expr = "the file {string} contains {string}")]

--- a/tests/features/doctor.feature
+++ b/tests/features/doctor.feature
@@ -1,0 +1,82 @@
+Feature: am doctor — readiness reporting
+  Reports what is and is not ready for a successful `am start`, without changing
+  anything. Exits non-zero when something would actually stop `am start` working, so
+  it can gate a setup script.
+
+  Scenario: a ready project reports ready and exits zero
+    Given a git repository
+    And am init has been run
+    And I am using a mock container runtime
+    When I run "am doctor"
+    Then the command succeeds
+    And the output contains "Ready"
+    And the output contains "git repository at"
+
+  Scenario: running outside a repository is reported, not thrown
+    Given no git repository
+    When I run "am doctor"
+    Then the command fails
+    And the output contains "not inside a git or jj repository"
+
+  Scenario: an uninitialized project points at am init
+    Given a git repository
+    And I am using a mock container runtime
+    When I run "am doctor"
+    Then the command fails
+    And the output contains "not initialized"
+    And the output contains "run 'am init'"
+
+  Scenario: a missing container runtime is a failure with install guidance
+    Given a git repository
+    And am init has been run
+    And I have set env "AM_CONTAINER_ENABLED" to "true"
+    And I have set env "AM_DOCKER_BIN" to "/nonexistent/docker"
+    When I run "am doctor" with env "AM_PODMAN_BIN" = "/nonexistent/podman"
+    Then the command fails
+    And the output contains "Podman"
+
+  Scenario: an unknown agent is rejected with the valid names
+    Given a git repository
+    And am init has been run
+    And I am using a mock container runtime
+    When I run "am doctor" with env "AM_AGENT" = "not-an-agent"
+    Then the command fails
+    And the output contains "unknown agent"
+    And the output contains "claude"
+
+  Scenario: a discovered devcontainer config is reported as the environment source
+    Given a git repository
+    And am init has been run
+    And I am using a mock devcontainer CLI
+    And the repo has a devcontainer config
+    When I run "am doctor"
+    Then the command succeeds
+    And the output contains "devcontainer at"
+    And the output contains "not built yet"
+
+  Scenario: initializeCommand is reported as refused before a session is ever started
+    Given a git repository
+    And am init has been run
+    And I am using a mock devcontainer CLI
+    And the repo has a devcontainer config with an initializeCommand
+    When I run "am doctor"
+    Then the command fails
+    And the output contains "runs on your host"
+    And the output contains "allow_host_commands"
+
+  Scenario: a compose config is reported as unsupported before a session is ever started
+    Given a git repository
+    And am init has been run
+    And I am using a mock devcontainer CLI
+    And the repo has a devcontainer config using docker compose
+    When I run "am doctor"
+    Then the command fails
+    And the output contains "dockerComposeFile"
+
+  # The whole point of the command: it is safe to run at any time.
+  Scenario: doctor changes nothing
+    Given a git repository
+    And I am using a mock container runtime
+    When I run "am doctor"
+    Then the worktree ".am/worktrees" does not exist
+    And the file ".am/config.toml" does not exist


### PR DESCRIPTION
Adds `am doctor`: report what is and is not ready for a successful `am start`, without changing anything.

Closes the backlog item, which grew several new checks once dev container support landed.

## What it checks

| Section | Checks |
|---|---|
| Repository | Inside a git or jj repo |
| Project setup | `.am/` initialized, git identity available |
| tmux | Binary present, and whether you are currently inside a session |
| Container runtime | Podman or Docker present, respecting `container.runtime` |
| Environment | Where the environment comes from, and whether that source is usable |
| Agent | Selected agent is known, and its credentials are present on this host |

In devcontainer mode the Environment section also reports the discovered config, the CLI and its version, Node ≥ 20, whether the built image is current for the config hash, and any construct `am` will refuse (`dockerComposeFile`) or drop (`initializeCommand`, `runArgs`).

## Design notes

**The checks call the same functions `cmd_start` does** — `detect_runtime`, `validate_agent_credentials`, `devcontainer::find_config`, and the same config-hash image naming. A passing report and a working `am start` therefore cannot drift apart, which is the only property that makes a doctor command worth trusting.

**Every failure carries its fix.** Statuses are `✓` ready, `!` usable but worth knowing, `✗` will stop `am start`, with the remedy indented underneath:

```
Environment
  ✓ source                 devcontainer at /path/to/.devcontainer/devcontainer.json
  ✗ devcontainer CLI       'devcontainer' not found on PATH
      → npm install -g @devcontainers/cli (needs Node 20+), or set container.mode = "image"
  ✓ node                   v22.23.2 (>= 20 required)
  ! built image            am-dc-f260010a69f5 not built yet
      → the next 'am start' will build it — this can take a few minutes
```

**Exit code** is 1 on any failure, 0 on warnings alone, so `am doctor && am start feat` gates a setup script.

**It mutates nothing.** That is what makes it the alternative to auto-bootstrapping `.am/` as a side effect of `am start`, which the backlog explicitly preferred against. There is a cucumber scenario asserting it creates nothing.

## Known limits, both stated in the docs

- Discovery runs against the **current checkout**, but a session gets a fresh worktree off `HEAD` — so an uncommitted `devcontainer.json` is not what that session will see.
- `privileged` and `capAdd` are label-only properties and cannot be reported until the image has been built, so only the config-visible gated constructs are checked.

## A test-harness bug this found

The cucumber mock devcontainer CLI did not handle `--version`. Doctor probes it, so the probe ran the mock's *build* body — creating the built-image marker and making an unbuilt image report as current. A mock artifact rather than a product bug, but one that would have made the new scenarios assert the wrong thing. The mock now answers `--version` without logging or building.

## Verification

- 279 unit tests, 62 cucumber scenarios (9 new for doctor), `cargo clippy -- -D warnings` clean
- Exercised by hand in four states: this repo (correctly flagged the missing devcontainer CLI and exited 1), outside a repository, with the CLI available, and in forced image mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9yaTHEeXsEMpP57QF7Ycf
