### PR TITLE
ci: add path filters and upload artifacts for PR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/ci.yml'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
@@ -41,8 +39,15 @@ jobs:
       - name: Test
         run: cargo test
 
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: am-x86_64-unknown-linux-gnu
+          path: target/debug/am
+          if-no-files-found: error
+
   cross-build:
-    name: Release build (${{ matrix.target }})
+    name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     # Linux is already build-checked by the `test` job. This job catches
     # macOS/Windows-specific compile breakage on PRs instead of only at release
@@ -66,5 +71,12 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
-      - name: Build (release, no packaging)
-        run: cargo build --release --target ${{ matrix.target }}
+      - name: Build
+        run: cargo build --target ${{ matrix.target }}
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: am-${{ matrix.target }}
+          path: target/${{ matrix.target }}/debug/am${{ matrix.target == 'x86_64-pc-windows-msvc' && '.exe' || '' }}
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- Add path filters so CI skips runs when only docs, dockerfiles, or unrelated workflow files change
- Upload debug build artifacts for Linux, macOS, and Windows so binaries are downloadable from the Actions UI for
pre-release testing
- Switch cross-build from release to debug (appropriate for PR testing)
- Remove push-to-main trigger (redundant with PR gating + release.yml)

## Test plan
- [ ] Open a PR touching only markdown — verify CI does not run
- [ ] Open a PR touching Rust code — verify CI runs and artifacts appear in the Actions summary