### PR TITLE
feat(claude): add .claude/settings.json with full container permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo *)",
+      "Bash(make *)",
+      "Bash(jj *)",
+      "Bash(git *)",
+      "Bash(rustup *)",
+      "Bash(ls *)",
+      "Bash(pwd)",
+      "Bash(cat *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(wc *)",
+      "Bash(sort *)",
+      "Bash(diff *)",
+      "Bash(mkdir *)",
+      "Bash(cp *)",
+      "Bash(mv *)",
+      "Bash(rm *)",
+      "Bash(chmod *)",
+      "Bash(touch *)",
+      "Bash(which *)",
+      "Bash(env)",
+      "Bash(echo *)",
+      "Bash(true)",
+      "Bash(test *)",
+      "Bash(apt-get *)",
+      "Bash(apt *)",
+      "Bash(dpkg *)",
+      "Bash(pip *)",
+      "Bash(pip3 *)",
+      "Bash(npm *)",
+      "Bash(npx *)",
+      "Bash(curl *)",
+      "Bash(wget *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add `.claude/settings.json` with pre-approved permissions for build, test, VCS, file operations, and package manager
commands
- Allows Claude Code to work autonomously inside containers without per-command approval prompts

## Test plan

- [ ] Start a new `am` session with Claude and verify no permission prompts for `cargo test`, `cargo clippy`, `jj
status`, etc.
- [ ] Verify unexpected commands (e.g., `ssh`, `docker`) still prompt for approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)