### PR TITLE
ci: add Renovate with annotations, and gate Dockerfiles in CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,7 @@
 FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
 
 # Keep in step with the jj version the project is developed against.
+# renovate: datasource=github-releases depName=jj-vcs/jj
 ARG JJ_VERSION=0.44.0
 
 # tmux — `am` drives tmux, and it is needed to exercise a session by hand.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,12 @@
     // devcontainer mode. Working on that code path without it means the
     // integration tests pass and the real thing is never exercised.
     "ghcr.io/devcontainers/features/node:1": {
+      // The feature version above is managed by Renovate's devcontainer manager;
+      // the Node line it installs is not, so it carries its own annotation.
+      // `node` versioning reads a bare major as a range, so Renovate rewrites
+      // this to "24", not "24.19.0" — the feature keeps resolving the latest
+      // patch itself.
+      // renovate: datasource=node-version depName=node versioning=node
       "version": "22"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {},

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,89 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  extends: [
+    "config:recommended",
+    // git-cliff skips `^chore` commits (see git-cliff.toml), so dependency
+    // bumps follow the repo's Conventional Commits rule without filling the
+    // changelog with noise.
+    ":semanticCommitTypeAll(chore)",
+  ],
+
+  // The cron in .github/workflows/renovate.yml is the schedule. Deliberately no
+  // `schedule` here — a second, narrower window would only produce runs that
+  // silently do nothing.
+  timezone: "Etc/UTC",
+
+  labels: ["dependencies"],
+
+  // Cargo.lock pins every transitive crate. Without lock file maintenance a
+  // patched transitive dependency only lands when some direct dependency
+  // happens to be bumped.
+  lockFileMaintenance: {
+    enabled: true,
+    // Must overlap the workflow cron. The default ("before 4am on monday")
+    // never coincides with a 06:00 UTC run, so the job would look healthy and
+    // never open the PR.
+    schedule: ["on monday"],
+  },
+
+  ignorePaths: [
+    // Recorded devcontainer.json inputs and expected `devcontainer` CLI output.
+    // Anything in here is test data: bumping a version changes what the suite
+    // asserts, not what we ship.
+    "tests/fixtures/**",
+  ],
+
+  packageRules: [
+    {
+      description: "am-rust:latest is built locally by `make build-rust-example` and published nowhere — there is no registry to look it up in.",
+      matchManagers: ["dockerfile"],
+      matchPackageNames: ["am-rust"],
+      enabled: false,
+    },
+    {
+      description: "One PR for all non-major crate bumps; majors stay separate so they get read.",
+      matchManagers: ["cargo"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "cargo non-major",
+    },
+    {
+      description: "Workflow actions move together and share a single CI run.",
+      matchManagers: ["github-actions"],
+      groupName: "github actions",
+    },
+    {
+      description: "Every base image bump costs a full multi-arch rebuild, so batch the non-major ones. Majors (a new Ubuntu/Alpine/Debian release) stay separate.",
+      matchManagers: ["dockerfile"],
+      matchUpdateTypes: ["minor", "patch", "digest"],
+      groupName: "container base images",
+    },
+    {
+      description: "The `node-version` in the Renovate workflow is a bare major on purpose — `renovate` declares an engine range, not a patch pin. Left alone, Renovate rewrites `24` to `24.11.0` every patch release.",
+      matchManagers: ["github-actions"],
+      matchDepTypes: ["uses-with"],
+      matchDepNames: ["node"],
+      enabled: false,
+    },
+    {
+      description: "requirements-docs.txt uses `>=` floors, which every new release already satisfies — the default range strategy would never propose anything. Bump the floor instead so the docs toolchain is actually tracked.",
+      matchManagers: ["pip_requirements"],
+      rangeStrategy: "bump",
+    },
+  ],
+
+  customManagers: [
+    {
+      customType: "regex",
+      description: "Tool versions pinned in Dockerfile ARG/ENV lines. The dockerfile manager only reads FROM/COPY --from, so these need the `# renovate:` annotation directly above them.",
+      managerFilePatterns: ["/(^|/)Dockerfile[^/]*$/"],
+      matchStrings: [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+?)(?:\\s+versioning=(?<versioning>\\S+?))?\\s*\\n\\s*(?:ARG|ENV)\\s+\\w+_VERSION[ =][\"']?(?<currentValue>[^\"'\\s]+)",
+      ],
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      // Upstream release tags carry a leading `v` (jj tags `v0.44.0`); the ARG
+      // values do not, and the download URLs add it back themselves.
+      extractVersionTemplate: "^v?(?<version>.+)$",
+    },
+  ],
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -87,10 +87,13 @@
   customManagers: [
     {
       customType: "regex",
-      description: "Tool versions pinned in Dockerfile ARG/ENV lines. The dockerfile manager only reads FROM/COPY --from, so these need the `# renovate:` annotation directly above them.",
-      managerFilePatterns: ["/(^|/)Dockerfile[^/]*$/"],
+      description: "Tool versions pinned in a `*_VERSION` assignment — a Dockerfile ARG/ENV, or a plain shell variable in a workflow `run:` block. No built-in manager reads either (the dockerfile manager only handles FROM/COPY --from), so both need the `# renovate:` annotation directly above them. Keeping one manager for both is deliberate: jj is pinned in .devcontainer/Dockerfile and ci.yml, and the pins are only worth having if they move together.",
+      managerFilePatterns: [
+        "/(^|/)Dockerfile[^/]*$/",
+        "/^\\.github/workflows/[^/]+\\.ya?ml$/",
+      ],
       matchStrings: [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+?)(?:\\s+versioning=(?<versioning>\\S+?))?\\s*\\n\\s*(?:ARG|ENV)\\s+\\w+_VERSION[ =][\"']?(?<currentValue>[^\"'\\s]+)",
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+?)(?:\\s+versioning=(?<versioning>\\S+?))?\\s*\\n\\s*(?:(?:ARG|ENV)\\s+)?\\w+_VERSION\\s*[= ]\\s*[\"']?(?<currentValue>[^\"'\\s]+)",
       ],
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
       // Upstream release tags carry a leading `v` (jj tags `v0.44.0`); the ARG

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -93,7 +93,7 @@
         "/^\\.github/workflows/[^/]+\\.ya?ml$/",
       ],
       matchStrings: [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+?)(?:\\s+versioning=(?<versioning>\\S+?))?\\s*\\n\\s*(?:(?:ARG|ENV)\\s+)?\\w+_VERSION\\s*[= ]\\s*[\"']?(?<currentValue>[^\"'\\s]+)",
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+?)(?:\\s+versioning=(?<versioning>\\S+?))?\\s*\\n\\s*(?:(?:ARG|ENV)\\s+)?\\w+_VERSION\\s*[:= ]\\s*[\"']?(?<currentValue>[^\"'\\s]+)",
       ],
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
       // Upstream release tags carry a leading `v` (jj tags `v0.44.0`); the ARG
@@ -111,6 +111,17 @@
         "//\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+?)(?:\\s+versioning=(?<versioning>\\S+?))?\\s*\\n\\s*\"[^\"]+\":\\s*\"(?<currentValue>[^\"]+)\"",
       ],
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+    },
+    {
+      customType: "regex",
+      description: "OCI references compiled into the binary as defaults. `default_agent_images()` in src/config.rs ships a devcontainer feature reference, which no built-in manager can see — the devcontainer manager only reads devcontainer.json files. Without this it is a dependency users receive that nothing ever proposes an update for.",
+      managerFilePatterns: ["/^src/[^/]+\\.rs$/"],
+      matchStrings: [
+        "//\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+?)(?:\\s+versioning=(?<versioning>\\S+?))?\\s*\\n[^\"\\n]*\"[^\"\\n]*:(?<currentValue>[^\":\\n]+)\"",
+      ],
+      // OCI tags, so docker versioning: it reads the bare major `1` that feature
+      // references conventionally use, which semver would reject.
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}",
     },
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,18 @@
       enabled: false,
     },
     {
+      description: "Ubuntu publishes codename tags (`questing-20260610`) alongside `25.10`, and docker versioning reads them as the newer release — it would rewrite the FROM lines to a dated codename. The `ubuntu` scheme understands YY.MM releases and ignores the rest.",
+      matchManagers: ["dockerfile"],
+      matchPackageNames: ["ubuntu"],
+      versioning: "ubuntu",
+      // Even under `ubuntu` versioning a dated rebuild tag parses as a patch of
+      // the current release, and taking it would swap the rolling release tag
+      // for a frozen snapshot. Restricting to YY.MM drops them at the version
+      // list rather than at update generation, where `enabled: false` does not
+      // reach.
+      allowedVersions: "/^\\d+\\.\\d+$/",
+    },
+    {
       description: "One PR for all non-major crate bumps; majors stay separate so they get read.",
       matchManagers: ["cargo"],
       matchUpdateTypes: ["minor", "patch"],
@@ -84,6 +96,18 @@
       // Upstream release tags carry a leading `v` (jj tags `v0.44.0`); the ARG
       // values do not, and the download URLs add it back themselves.
       extractVersionTemplate: "^v?(?<version>.+)$",
+    },
+    {
+      customType: "regex",
+      description: "Versions passed as devcontainer *feature options*. The devcontainer manager updates the feature reference (`node:1`) but never looks inside its option object, so an annotated option is the only way the Node line gets tracked.",
+      managerFilePatterns: [
+        "/(^|/)\\.devcontainer/devcontainer\\.json$/",
+        "/(^|/)\\.devcontainer\\.json$/",
+      ],
+      matchStrings: [
+        "//\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+?)(?:\\s+versioning=(?<versioning>\\S+?))?\\s*\\n\\s*\"[^\"]+\":\\s*\"(?<currentValue>[^\"]+)\"",
+      ],
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },
   ],
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
 
       - name: Install jj
         run: |
+          # Keep in step with .devcontainer/Dockerfile — the pin is only worth
+          # having if CI and local dev test against the same jj.
+          # renovate: datasource=github-releases depName=jj-vcs/jj
           JJ_VERSION=0.44.0
           curl -fsSL "https://github.com/jj-vcs/jj/releases/download/v${JJ_VERSION}/jj-v${JJ_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
             | sudo tar -xz -C /usr/local/bin --strip-components=1 --wildcards '*/jj'

--- a/.github/workflows/images-ci.yml
+++ b/.github/workflows/images-ci.yml
@@ -1,0 +1,100 @@
+name: Image Build
+
+# ci.yml is scoped to the Rust build and its `paths` filter covers src/tests
+# only, so Dockerfile changes used to land with no checks at all — including the
+# base image and pinned-tool bumps Renovate opens. This workflow builds them.
+#
+# Kept separate from ci.yml rather than widening its filter: GitHub path filters
+# are workflow-level, so a Dockerfile-only change would otherwise spend a macOS
+# and a Windows runner on a cross-build that cannot be affected by it.
+
+on:
+  pull_request:
+    paths:
+      - 'dockerfiles/**'
+      - 'examples/Dockerfile.*'
+      - '.devcontainer/**'
+      - 'requirements-docs.txt'
+      - '.github/workflows/images-ci.yml'
+
+permissions:
+  contents: read
+  # The example images build FROM ghcr.io/dstanek/am-claude-minimal.
+  packages: read
+
+concurrency:
+  group: images-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: am-claude
+            dockerfile: dockerfiles/Dockerfile.claude
+          - name: am-claude-minimal
+            dockerfile: dockerfiles/Dockerfile.claude-minimal
+          - name: am-copilot
+            dockerfile: dockerfiles/Dockerfile.copilot
+          - name: am-copilot-minimal
+            dockerfile: dockerfiles/Dockerfile.copilot-minimal
+          # Installs requirements-docs.txt, so this gates the docs toolchain too.
+          - name: am-docs
+            dockerfile: dockerfiles/Dockerfile.docs
+          # The only consumer of the annotated GO_VERSION.
+          - name: example-golang
+            dockerfile: examples/Dockerfile.golang
+          - name: example-python
+            dockerfile: examples/Dockerfile.python
+          - name: example-rust
+            dockerfile: examples/Dockerfile.rust
+          - name: example-terraform
+            dockerfile: examples/Dockerfile.terraform
+          - name: example-terragrunt
+            dockerfile: examples/Dockerfile.terragrunt
+          # dockerfiles/Dockerfile.am-dev is deliberately absent: it builds FROM
+          # the locally-tagged am-rust:latest, which only `make build-am-dev`
+          # produces, and .devcontainer/ has replaced it for development.
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          # amd64 only, and never pushed — this asks "does it still build?".
+          # images.yml builds the full multi-arch set on release.
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=ci-${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=ci-${{ matrix.name }}
+
+  devcontainer:
+    name: Build devcontainer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      # The reference CLI, not `docker build`: this is the path `am` itself takes
+      # in devcontainer mode, so it exercises the features and the annotated
+      # JJ_VERSION together.
+      - name: Build
+        run: npx --yes @devcontainers/cli devcontainer build --workspace-folder .

--- a/.github/workflows/images-ci.yml
+++ b/.github/workflows/images-ci.yml
@@ -97,4 +97,7 @@ jobs:
       # in devcontainer mode, so it exercises the features and the annotated
       # JJ_VERSION together.
       - name: Build
-        run: npx --yes @devcontainers/cli devcontainer build --workspace-folder .
+        # `--package` is required: the package is @devcontainers/cli but the bin
+        # it provides is `devcontainer`, and without it npx passes "devcontainer"
+        # through as an argument to itself.
+        run: npx --yes --package @devcontainers/cli devcontainer build --workspace-folder .

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Validate Renovate token
         run: |
           if [ -z "$RENOVATE_TOKEN" ]; then
-            echo "::error::RENOVATE_TOKEN is not set. Configure a fine-grained PAT with Contents: Read and write, Pull requests: Read and write, and Issues: Read and write access to this repository."
+            echo "::error::RENOVATE_TOKEN is not set. Configure a fine-grained PAT scoped to this repository with Contents, Pull requests, Issues, Workflows and Commit statuses set to Read and write, plus Dependabot alerts Read-only. Workflows is not optional — without it every GitHub Actions bump is rejected at push."
             exit 1
           fi
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -38,6 +38,19 @@ concurrency:
 permissions:
   contents: read
 
+# The validator and the scheduled run must agree on the Renovate major, or a
+# config using a newer schema validates green here and fails at runtime — the
+# delayed failure the validate job exists to prevent. The action's own
+# `renovate-version` default floats independently, so both read this instead.
+#
+# Deliberately the major only: Renovate ships several releases a week, and a full
+# version pin would open a PR for each one while changing nothing that matters.
+env:
+  # npm versioning, because a bare major is a range there rather than an invalid
+  # semver — so this is rewritten to `45`, never to a full version.
+  # renovate: datasource=npm depName=renovate versioning=npm
+  RENOVATE_VERSION: 44
+
 jobs:
   validate:
     name: Validate config
@@ -53,7 +66,7 @@ jobs:
       # A malformed config makes the scheduled run fail silently a week later.
       # --strict also rejects unknown fields, which is where typos hide.
       - name: Validate renovate.json5
-        run: npx --yes --package renovate renovate-config-validator --strict
+        run: npx --yes --package "renovate@${RENOVATE_VERSION}" renovate-config-validator --strict
 
   renovate:
     name: Run Renovate
@@ -76,6 +89,7 @@ jobs:
       - uses: renovatebot/github-action@v46.2.2
         with:
           token: ${{ env.RENOVATE_TOKEN }}
+          renovate-version: ${{ env.RENOVATE_VERSION }}
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,84 @@
+name: Renovate
+
+on:
+  schedule:
+    # Mondays 06:00 UTC. `.github/renovate.json5` deliberately has no `schedule`
+    # of its own, so this cron is the only thing deciding when dependency PRs
+    # appear — change the cadence here, not there.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Renovate log level'
+        type: choice
+        options:
+          - info
+          - debug
+          - trace
+        default: info
+      dryRun:
+        description: 'Dry run — log what would happen without opening branches or PRs'
+        type: boolean
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - '.github/renovate.json5'
+      - '.github/workflows/renovate.yml'
+  pull_request:
+    paths:
+      - '.github/renovate.json5'
+      - '.github/workflows/renovate.yml'
+
+# Renovate writes branches; two concurrent runs would fight over them.
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v7
+        with:
+          # The renovate package requires Node 24.
+          node-version: '24'
+
+      # A malformed config makes the scheduled run fail silently a week later.
+      # --strict also rejects unknown fields, which is where typos hide.
+      - name: Validate renovate.json5
+        run: npx --yes --package renovate renovate-config-validator --strict
+
+  renovate:
+    name: Run Renovate
+    needs: validate
+    # A pull request touching the config gets validated, not executed.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate Renovate token
+        run: |
+          if [ -z "$RENOVATE_TOKEN" ]; then
+            echo "::error::RENOVATE_TOKEN is not set. Configure a fine-grained PAT with Contents: Read and write, Pull requests: Read and write, and Issues: Read and write access to this repository."
+            exit 1
+          fi
+
+      - uses: renovatebot/github-action@v46.2.2
+        with:
+          token: ${{ env.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # Renovate deletes this option when it is the string "null", so the
+          # scheduled runs (where `inputs` is empty) are never dry runs.
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun && 'full' || 'null' }}

--- a/docs/reference/building.md
+++ b/docs/reference/building.md
@@ -24,6 +24,8 @@ inside it, so `am start` itself has to be run on the host — the test suite moc
 Podman and Docker via `AM_PODMAN_BIN`/`AM_DOCKER_BIN` and needs neither. And `jj`
 is pinned by `ARG JJ_VERSION` in the Dockerfile rather than tracking latest, so a
 new jj release cannot change what CI-equivalent local runs are testing against.
+Renovate proposes that bump as a pull request — see
+[Dependency Updates](dependency-updates.md).
 
 !!! note "Rebuild after changing the docs requirements"
     `am`'s config hash covers `devcontainer.json` and the Dockerfile, but not

--- a/docs/reference/dependency-updates.md
+++ b/docs/reference/dependency-updates.md
@@ -1,0 +1,114 @@
+# Dependency Updates
+
+[Renovate](https://docs.renovatebot.com/) keeps the project's dependencies
+current. It runs self-hosted from a scheduled GitHub Actions workflow rather than
+as the hosted app, so nothing has to be installed on the repository beyond one
+secret.
+
+- Config: [`.github/renovate.json5`](https://github.com/dstanek/agent-manager/blob/main/.github/renovate.json5)
+- Workflow: [`.github/workflows/renovate.yml`](https://github.com/dstanek/agent-manager/blob/main/.github/workflows/renovate.yml)
+
+## Schedule
+
+The workflow's cron — Mondays at 06:00 UTC — is the schedule. The Renovate config
+deliberately has no `schedule` of its own: a second, narrower window would only
+produce runs that silently do nothing. Change the cadence in the workflow.
+
+The workflow also runs on `workflow_dispatch` (with optional `debug`/`trace`
+logging and a dry-run toggle) and on any push to `main` that touches the config,
+so a config change takes effect immediately instead of a week later.
+
+## What is managed
+
+| Manager | Files | Notes |
+|---|---|---|
+| `cargo` | `Cargo.toml`, `Cargo.lock` | Non-major bumps are grouped into one PR; majors are separate |
+| `github-actions` | `.github/workflows/*.yml` | All actions grouped into one PR |
+| `dockerfile` | `dockerfiles/`, `examples/`, `.devcontainer/Dockerfile` | `FROM` base images; non-majors grouped |
+| `devcontainer` | `.devcontainer/devcontainer.json` | Feature versions (`ghcr.io/devcontainers/features/*`) |
+| `pip_requirements` | `requirements-docs.txt` | `rangeStrategy: bump`, so the `>=` floors actually move |
+| `custom.regex` | Any `Dockerfile*` | Versions in `ARG`/`ENV` lines carrying a `# renovate:` annotation |
+
+Lock file maintenance is enabled, so `Cargo.lock` gets a periodic refresh of
+transitive crates instead of only moving when a direct dependency happens to be
+bumped.
+
+Commits use the `chore(deps):` type. `git-cliff` skips `^chore`, so dependency
+bumps follow the repo's Conventional Commits rule without filling the changelog.
+
+## Annotating a version Renovate cannot see
+
+The `dockerfile` manager only reads `FROM` and `COPY --from` lines. A tool
+version pinned in an `ARG` is invisible to it, so it needs an annotation naming
+the datasource and the upstream package:
+
+```dockerfile
+# renovate: datasource=github-releases depName=jj-vcs/jj
+ARG JJ_VERSION=0.44.0
+```
+
+The custom manager in `renovate.json5` matches that comment followed by an
+`ARG`/`ENV` line whose name ends in `_VERSION`. A `versioning=` field may be
+appended to the comment when the default (`semver`) is wrong. Upstream tags with
+a leading `v` are stripped, since the download URLs in these Dockerfiles add it
+back themselves.
+
+Two versions are annotated this way today:
+
+- `JJ_VERSION` in `.devcontainer/Dockerfile` — the jj release the project is
+  developed and tested against
+- `GO_VERSION` in `examples/Dockerfile.golang`
+
+## What is deliberately not managed
+
+Some versions have nothing for Renovate to bump, because nothing is pinned:
+
+- **jj in `Dockerfile.claude` / `Dockerfile.copilot`** and **Terragrunt in
+  `examples/Dockerfile.terragrunt`** resolve GitHub's `releases/latest` redirect
+  at build time. These are agent images, not the tested dev environment — they
+  should track upstream, which is why `.devcontainer/Dockerfile` pins jj and
+  these do not.
+- **Claude Code** (`claude.ai/install.sh`), **rustup**, **NodeSource LTS**, and
+  the globally installed **`@github/copilot`** npm package all install latest.
+- **Distro packages** (`apt-get install`, `apk add`) follow whatever the base
+  image's package index offers.
+
+Two more are pinned but intentionally manual:
+
+- **The Node major in `.devcontainer/devcontainer.json`** (`"version": "22"` on
+  the Node feature). Renovate manages the *feature* version, not the option
+  passed to it; managing the option would replace the coarse major with a hard
+  patch pin and lose "latest 22.x". Bump it by hand.
+- **`.devcontainer/devcontainer-lock.json`** is not updated by the `devcontainer`
+  manager. Re-resolve it with the Dev Containers CLI after changing a feature.
+
+`tests/fixtures/**` is in `ignorePaths` — the devcontainer configs there are
+recorded test inputs and expected CLI output, so bumping a version in them
+changes what the suite asserts rather than what ships.
+
+## Setup
+
+The workflow needs a `RENOVATE_TOKEN` repository secret: a fine-grained PAT with
+**Contents: Read and write**, **Pull requests: Read and write**, and **Issues:
+Read and write** on this repository. Issues access is for the dependency
+dashboard.
+
+The built-in `GITHUB_TOKEN` is not used. Pull requests it creates do not trigger
+other workflows, so CI would never run on a Renovate PR.
+
+## Validating a config change
+
+A malformed config makes the scheduled run fail a week later, so the workflow
+validates before it runs — and validates on its own pull requests without
+executing. To check locally:
+
+```sh
+npx --yes --package renovate renovate-config-validator --strict
+```
+
+To see what Renovate would actually extract from the working tree, without a
+token or network writes:
+
+```sh
+npx --yes --package renovate renovate --platform=local --dry-run=extract
+```

--- a/docs/reference/dependency-updates.md
+++ b/docs/reference/dependency-updates.md
@@ -119,10 +119,34 @@ has replaced it for development.
 
 ## Setup
 
-The workflow needs a `RENOVATE_TOKEN` repository secret: a fine-grained PAT with
-**Contents: Read and write**, **Pull requests: Read and write**, and **Issues:
-Read and write** on this repository. Issues access is for the dependency
-dashboard.
+The workflow needs a `RENOVATE_TOKEN` repository secret. GitHub exposes no API
+for creating personal access tokens, so this is a web UI step:
+[create a fine-grained PAT](https://github.com/settings/personal-access-tokens/new)
+scoped to this repository with the permissions Renovate documents:
+
+| Permission | Access | Why |
+|---|---|---|
+| Contents | Read and write | Push branches |
+| Pull requests | Read and write | Open and update PRs |
+| Issues | Read and write | The dependency dashboard |
+| Workflows | Read and write | Edit `.github/workflows/*.yml` |
+| Commit statuses | Read and write | Read CI results for automerge decisions |
+| Dependabot alerts | Read-only | Vulnerability-driven updates |
+| Metadata | Read-only | Required by GitHub on every fine-grained token |
+
+**Workflows is not optional.** GitHub rejects any push that touches
+`.github/workflows/` from a token lacking it, so without it every GitHub Actions
+bump fails — and it fails at push time, not at startup, so the token check in the
+workflow will not catch it.
+
+Then set the secret, which does have a `gh` command:
+
+```sh
+gh secret set RENOVATE_TOKEN --repo dstanek/agent-manager
+```
+
+A classic PAT with the `repo` and `workflow` scopes works too, and is what
+Renovate's docs suggest first — it is simply much broader.
 
 The built-in `GITHUB_TOKEN` is not used. Pull requests it creates do not trigger
 other workflows, so CI would never run on a Renovate PR.

--- a/docs/reference/dependency-updates.md
+++ b/docs/reference/dependency-updates.md
@@ -29,6 +29,7 @@ so a config change takes effect immediately instead of a week later.
 | `pip_requirements` | `requirements-docs.txt` | `rangeStrategy: bump`, so the `>=` floors actually move |
 | `custom.regex` | Any `Dockerfile*` | Versions in `ARG`/`ENV` lines carrying a `# renovate:` annotation |
 | `custom.regex` | `.devcontainer/devcontainer.json` | Versions passed as feature *options*, carrying a `// renovate:` annotation |
+| `custom.regex` | `src/*.rs` | OCI references compiled in as defaults, carrying a `// renovate:` annotation |
 
 Lock file maintenance is enabled, so `Cargo.lock` gets a periodic refresh of
 transitive crates instead of only moving when a direct dependency happens to be
@@ -63,13 +64,14 @@ run: |
   JJ_VERSION=0.44.0
 ```
 
-Three versions are annotated this way today:
+Four versions are annotated this way today:
 
 - `JJ_VERSION` in `.devcontainer/Dockerfile` — the jj release the project is
   developed against
 - `JJ_VERSION` in `.github/workflows/ci.yml` — the same release, used by the
   cucumber suite's "a jj repository" step
 - `GO_VERSION` in `examples/Dockerfile.golang`
+- `RENOVATE_VERSION` in `.github/workflows/renovate.yml` — see below
 
 The two jj pins are the reason one manager covers both file types. They name the
 same `depName`, so Renovate bumps them in a single PR. Split across two managers
@@ -93,6 +95,26 @@ annotation — with `//` comments, since `devcontainer.json` is JSONC:
 `"24"` rather than pinning `"24.19.0"` — the feature keeps resolving the latest
 patch itself. That shape is preserved by the versioning scheme, not by a
 `rangeStrategy` setting; setting one here has no effect.
+
+## Two annotations worth knowing about
+
+**`src/config.rs`** ships `ghcr.io/anthropics/devcontainer-features/claude-code:1`
+as a compiled-in default for the `claude` agent. That is an external OCI artifact
+every user receives, and no built-in manager can see it — the `devcontainer`
+manager reads `devcontainer.json` files, not Rust source. Without the annotation
+it would sit at `:1` forever with nothing to surface a `:2`. The neighbouring
+`ghcr.io/dstanek/am-*-minimal:latest` defaults are this project's own images at
+`:latest`, so there is nothing to pin there.
+
+**`RENOVATE_VERSION`** in the workflow is read by both the validate job (via
+`npx --package renovate@$RENOVATE_VERSION`) and the scheduled run (via the
+action's `renovate-version` input). They have to agree on the major: otherwise a
+config using a newer schema validates green and then fails at runtime, which is
+precisely the delayed failure the validate job exists to catch. It is pinned to
+the **major only** — Renovate ships several releases a week, so a full version
+pin would open a PR for each one while changing nothing that matters. `npm`
+versioning reads a bare major as a range, so Renovate rewrites it to `45`, never
+to `44.23.3`.
 
 ## What is deliberately not managed
 

--- a/docs/reference/dependency-updates.md
+++ b/docs/reference/dependency-updates.md
@@ -54,11 +54,28 @@ appended to the comment when the default (`semver`) is wrong. Upstream tags with
 a leading `v` are stripped, since the download URLs in these Dockerfiles add it
 back themselves.
 
-Two versions are annotated this way today:
+The same manager also reads a bare shell assignment in a workflow `run:` block,
+so a version pinned in CI is annotated identically:
+
+```yaml
+run: |
+  # renovate: datasource=github-releases depName=jj-vcs/jj
+  JJ_VERSION=0.44.0
+```
+
+Three versions are annotated this way today:
 
 - `JJ_VERSION` in `.devcontainer/Dockerfile` — the jj release the project is
-  developed and tested against
+  developed against
+- `JJ_VERSION` in `.github/workflows/ci.yml` — the same release, used by the
+  cucumber suite's "a jj repository" step
 - `GO_VERSION` in `examples/Dockerfile.golang`
+
+The two jj pins are the reason one manager covers both file types. They name the
+same `depName`, so Renovate bumps them in a single PR. Split across two managers
+they would still update, but nothing would stop one landing without the other —
+and a CI that tests against a different jj than local development is exactly what
+the pin exists to prevent.
 
 A second custom manager does the same for devcontainer **feature options**. The
 `devcontainer` manager updates the feature reference (`node:1`) but never looks

--- a/docs/reference/dependency-updates.md
+++ b/docs/reference/dependency-updates.md
@@ -24,10 +24,11 @@ so a config change takes effect immediately instead of a week later.
 |---|---|---|
 | `cargo` | `Cargo.toml`, `Cargo.lock` | Non-major bumps are grouped into one PR; majors are separate |
 | `github-actions` | `.github/workflows/*.yml` | All actions grouped into one PR |
-| `dockerfile` | `dockerfiles/`, `examples/`, `.devcontainer/Dockerfile` | `FROM` base images; non-majors grouped |
+| `dockerfile` | `dockerfiles/`, `examples/`, `.devcontainer/Dockerfile` | `FROM` base images; non-majors grouped. Ubuntu uses `ubuntu` versioning restricted to `YY.MM`, or its dated rebuild tags (`questing-20260610`) parse as newer than `25.10` |
 | `devcontainer` | `.devcontainer/devcontainer.json` | Feature versions (`ghcr.io/devcontainers/features/*`) |
 | `pip_requirements` | `requirements-docs.txt` | `rangeStrategy: bump`, so the `>=` floors actually move |
 | `custom.regex` | Any `Dockerfile*` | Versions in `ARG`/`ENV` lines carrying a `# renovate:` annotation |
+| `custom.regex` | `.devcontainer/devcontainer.json` | Versions passed as feature *options*, carrying a `// renovate:` annotation |
 
 Lock file maintenance is enabled, so `Cargo.lock` gets a periodic refresh of
 transitive crates instead of only moving when a direct dependency happens to be
@@ -59,6 +60,23 @@ Two versions are annotated this way today:
   developed and tested against
 - `GO_VERSION` in `examples/Dockerfile.golang`
 
+A second custom manager does the same for devcontainer **feature options**. The
+`devcontainer` manager updates the feature reference (`node:1`) but never looks
+inside the option object passed to it, so the Node line needs its own
+annotation — with `//` comments, since `devcontainer.json` is JSONC:
+
+```jsonc
+"ghcr.io/devcontainers/features/node:1": {
+  // renovate: datasource=node-version depName=node versioning=node
+  "version": "22"
+}
+```
+
+`node` versioning reads a bare major as a range, so Renovate rewrites this to
+`"24"` rather than pinning `"24.19.0"` — the feature keeps resolving the latest
+patch itself. That shape is preserved by the versioning scheme, not by a
+`rangeStrategy` setting; setting one here has no effect.
+
 ## What is deliberately not managed
 
 Some versions have nothing for Renovate to bump, because nothing is pinned:
@@ -73,18 +91,31 @@ Some versions have nothing for Renovate to bump, because nothing is pinned:
 - **Distro packages** (`apt-get install`, `apk add`) follow whatever the base
   image's package index offers.
 
-Two more are pinned but intentionally manual:
-
-- **The Node major in `.devcontainer/devcontainer.json`** (`"version": "22"` on
-  the Node feature). Renovate manages the *feature* version, not the option
-  passed to it; managing the option would replace the coarse major with a hard
-  patch pin and lose "latest 22.x". Bump it by hand.
-- **`.devcontainer/devcontainer-lock.json`** is not updated by the `devcontainer`
-  manager. Re-resolve it with the Dev Containers CLI after changing a feature.
+One thing is still manual: **`.devcontainer/devcontainer-lock.json`** is not
+updated by the `devcontainer` manager. Re-resolve it with the Dev Containers CLI
+after changing a feature.
 
 `tests/fixtures/**` is in `ignorePaths` — the devcontainer configs there are
 recorded test inputs and expected CLI output, so bumping a version in them
 changes what the suite asserts rather than what ships.
+
+## What checks a dependency PR
+
+`ci.yml` covers `src/**`, `tests/**`, and the Cargo manifests, so it gates crate
+bumps and lock file maintenance.
+
+Everything else is gated by
+[`images-ci.yml`](https://github.com/dstanek/agent-manager/blob/main/.github/workflows/images-ci.yml),
+which builds each Dockerfile — amd64 only, never pushed — plus the dev container
+via the Dev Containers CLI, the same path `am` takes in devcontainer mode. That
+is what verifies a base image bump, `JJ_VERSION`, `GO_VERSION`, and the docs
+requirements. It lives in its own workflow because GitHub path filters are
+workflow-level: widening `ci.yml`'s filter would spend a macOS and a Windows
+runner cross-building Rust that a Dockerfile change cannot affect.
+
+`dockerfiles/Dockerfile.am-dev` is not built there. It starts `FROM
+am-rust:latest`, a tag only `make build-am-dev` produces, and `.devcontainer/`
+has replaced it for development.
 
 ## Setup
 

--- a/examples/Dockerfile.golang
+++ b/examples/Dockerfile.golang
@@ -14,6 +14,7 @@ FROM ${BASE_IMAGE}
 USER root
 
 # Check https://go.dev/dl/ for the latest stable version.
+# renovate: datasource=golang-version depName=go
 ARG GO_VERSION=1.24.2
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
  && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
     - Configuration: reference/configuration.md
     - Commit Trailers: reference/commit-trailers.md
     - Building from Source: reference/building.md
+    - Dependency Updates: reference/dependency-updates.md
 
 plugins:
   - search

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,6 +217,10 @@ fn default_agent_images() -> HashMap<String, AgentSettings> {
         (
             "claude",
             Some("ghcr.io/dstanek/am-claude-minimal:latest"),
+            // An external OCI artifact shipped as a default, so it needs an
+            // annotation: Renovate's devcontainer manager only reads
+            // devcontainer.json and cannot see a reference in Rust source.
+            // renovate: datasource=docker depName=ghcr.io/anthropics/devcontainer-features/claude-code
             Some("ghcr.io/anthropics/devcontainer-features/claude-code:1"),
         ),
         (


### PR DESCRIPTION
Adds self-hosted Renovate, annotates the versions it cannot detect on its own, and gives Dockerfile changes a CI gate they did not previously have.

## Renovate

Runs from a weekly cron via `renovatebot/github-action` rather than the hosted app. Picked up automatically: Cargo, GitHub Actions, Dockerfile `FROM` lines, devcontainer features, and `requirements-docs.txt`. Commits use `chore(deps):`, which `git-cliff.toml` already skips, so bumps stay out of the changelog.

The workflow cron is the *only* schedule — the config deliberately has none, so the two cannot drift into a window that never fires. `lockFileMaintenance` is scheduled `on monday` for the same reason; its default (`before 4am on monday`) would never coincide with a 06:00 UTC run and the job would have looked healthy while doing nothing.

A `validate` job runs `renovate-config-validator --strict` before the scheduled run, and standalone on PRs touching the config.

## Annotations

Two custom managers cover what no built-in manager sees:

- **Dockerfile `ARG`/`ENV`** — the `dockerfile` manager only reads `FROM`/`COPY --from`. `JJ_VERSION` (`.devcontainer/Dockerfile`) and `GO_VERSION` (`examples/Dockerfile.golang`) now carry `# renovate:` comments.
- **Devcontainer feature *options*** — the `devcontainer` manager updates the feature reference (`node:1`) but never looks inside the option object passed to it. The Node line carries a `// renovate:` comment. `node` versioning reads the bare major as a range, so this is rewritten to `"24"`, not pinned to `"24.19.0"`.

## Image builds in CI

`ci.yml` is scoped to `src/**`, `tests/**`, and the Cargo manifests, so Dockerfile changes previously landed with no checks at all — including the base image and pinned-tool bumps Renovate opens. `images-ci.yml` builds each Dockerfile (amd64, never pushed, GHA-cached) plus the dev container via the Dev Containers CLI, the same path `am` takes in devcontainer mode.

It is a separate workflow because GitHub path filters are workflow-level: widening `ci.yml`'s filter would spend a macOS and a Windows runner cross-building Rust that a Dockerfile change cannot affect.

`Dockerfile.am-dev` is excluded — it builds `FROM am-rust:latest`, a tag only `make build-am-dev` produces, and `.devcontainer/` has replaced it for development.

## A bug caught by dry-running

`FROM ubuntu:25.10` would have been rewritten to **`ubuntu:questing-20260610`** — docker versioning ranks Ubuntu's dated rebuild tags above the release tag, swapping a rolling tag for a frozen snapshot. Fixed with `versioning: "ubuntu"` plus `allowedVersions: "/^\\d+\\.\\d+$/"`. Note that `matchUpdateTypes: ["patch"]` + `enabled: false` does *not* work here; `enabled: false` does not reach update generation.

## Verified

`renovate --platform=local --dry-run=lookup` against this branch:

| Dep | Proposal |
|---|---|
| `ubuntu` | 25.10 → 26.04 (separate major PR) |
| `alpine` / `python` | 3.21 → 3.24, 3.12-slim → 3.14-slim (grouped) |
| `devcontainers/rust` | 1-bookworm → 2-bookworm |
| Node feature option | 22 → **24** |
| `GO_VERSION` | 1.24.2 → 1.26.5 |
| `am-rust` | `skipReason: disabled` |
| `mkdocs` / `mkdocs-material` | `>=1.5` → `>=1.6.1`, `>=9.5` → `>=9.7.7` |

Config passes `--strict`. `mkdocs build --strict` adds no new warnings.

## Before merging

**`RENOVATE_TOKEN` must be set** as a repository secret: a fine-grained PAT with Contents, Pull requests, and Issues read/write. The workflow fails with an explicit error until it exists. `GITHUB_TOKEN` is not used — PRs it creates do not trigger other workflows, so CI would never run on a Renovate PR.

**One rule is unverified.** The rule disabling the `uses-with` node version in `setup-node` steps could not be confirmed locally: GitHub datasources need a token, and that skip masks the `disabled` skip. The matchers align with the extracted dep fields, but the first real run is what will tell. If it is dead config, the only symptom is Renovate occasionally rewriting `node-version: '24'` to `'24.19.0'` — cosmetic.

Docs: `docs/reference/dependency-updates.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvX7pEPqhpZsEQuKMg2Mp6