### PR TITLE
feat(session): centralize session state in XDG_STATE_HOME

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install jj
+        run: |
+          JJ_VERSION=0.44.0
+          curl -fsSL "https://github.com/jj-vcs/jj/releases/download/v${JJ_VERSION}/jj-v${JJ_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin --strip-components=1 --wildcards '*/jj'
+          jj --version
+
       - name: Build
         run: cargo build
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "chrono",
  "clap",
  "cucumber",
+ "fs2",
  "serde",
  "serde_json",
  "serde_json_lenient",
@@ -415,6 +416,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures"
@@ -1459,6 +1470,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1493,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ which = "6"
 chrono = { version = "0.4", features = ["serde"] }
 serde_json_lenient = "0.2.4"
 sha2 = "0.11.0"
+fs2 = "0.4"
 
 [profile.release]
 strip = true

--- a/docs/prd/global-session-state.md
+++ b/docs/prd/global-session-state.md
@@ -1,0 +1,761 @@
+# PRD: Global Session State
+
+## Feature Overview
+
+Move the session registry from a per-repo file (`<repo>/.am/sessions.json`) to a global
+location (`$XDG_STATE_HOME/am/sessions.json`) so that `am` can list and manage sessions
+from any working directory. As a by-product, `.am/config.toml` becomes committable because
+the only non-committable artifact it contained (the sessions file) moves out.
+
+**User value:**
+- `am list` works from any directory, not just the repo where a session was started.
+- Teams can commit `.am/config.toml` to share `agent`, `container`, and `devcontainer` defaults
+  without each developer recreating them.
+- Stale session records (from deleted or renamed repos) are surfaced and cleanable rather
+  than silently rotting.
+
+**Success criteria (how we know it is done):**
+1. `am list` (scoped to current repo) returns the same output as before this change when run
+   from the repo root.
+2. `am list --all` returns sessions from all repos, with `[stale]` annotation for repos
+   whose path no longer exists.
+3. `am start`, `am destroy`, `am attach`, and `am run` all work without an
+   `.am/sessions.json` file present.
+4. `am init` no longer creates `.am/sessions.json` or `.am/gitconfig`; it writes only
+   `.am/config.toml` and adds `.am/worktrees/` to `.gitignore`.
+5. Running any `am` command against a repo that has an old-style `.am/sessions.json`
+   migrates its records to the global store transparently and deletes the old file.
+6. `am session rm <slug> --repo <path>` removes an orphaned record and attempts container
+   and tmux cleanup.
+7. Existing tests pass; new tests cover the global state path, migration, stale detection,
+   and `am session rm`.
+
+---
+
+## Assumptions
+
+1. **XDG_STATE_HOME default:** When `$XDG_STATE_HOME` is unset, `am` falls back to
+   `~/.local/state` per the XDG Base Directory Specification. This parallels how
+   `global_config_path()` already handles `$XDG_CONFIG_HOME`.
+2. **sessions.json schema is additive:** Adding the `repo_root` field is backward-compatible
+   because serde deserialises unknown fields without error, and old records without `repo_root`
+   are treated as belonging to the repo where the migration finds them.
+3. **Gitconfig generation at session start:** `am start` calls `git config get user.name`
+   and `git config get user.email` (already done by the existing `read_git_config` helper)
+   and writes a temporary gitconfig to a well-known path inside the global state directory
+   rather than `.am/gitconfig`. This file is transient (not version-controlled).
+4. **Migration is one-way:** Records are migrated from the old file to the global store;
+   `am` never writes back to `.am/sessions.json` after migration.
+5. **`am session rm` is destructive:** It removes the session record and makes a
+   best-effort attempt to stop and remove the container and kill the tmux window. Errors in
+   cleanup are logged as warnings, not failures — the record is always removed.
+6. **`.am/worktrees/` in `.gitignore` is an additive change:** If `.am/` is already in
+   `.gitignore`, `am init` still adds `.am/worktrees/` as the canonical entry. If both are
+   present, the more-specific entry is harmless. The old broad `.am/` entry is left in place
+   (removing it risks exposing already-ignored files to `git status`); an advisory message
+   is printed if the old entry is detected.
+7. **No global sessions.json pre-creation:** The global sessions file is created on first
+   write (first `am start` or migration), not by `am init`. This matches how the config
+   file works.
+8. **`am session rm` without `--repo`:** If the slug is unique across all repos, it
+   resolves unambiguously from anywhere. If the slug exists in multiple repos and the user
+   is inside one of them, it resolves to that repo. Otherwise, `--repo` is required to
+   disambiguate.
+9. **Transient gitconfig path:** The generated gitconfig is written to
+   `$XDG_STATE_HOME/am/gitconfig` (a single file shared across sessions, regenerated at
+   each `am start`). It does not need to be per-session because its contents come from the
+   user's global git config and do not change between sessions.
+
+---
+
+## Resolved Questions
+
+1. **Gitconfig path for containers:** `$XDG_STATE_HOME/am/gitconfig` is the correct
+   location. It is regenerated at each `am start` and is transient. The
+   `ContainerMounts.gitconfig_host` default changes from `<repo>/.am/gitconfig` to this
+   path.
+
+2. **`am session rm` partial cleanup failure:** Best-effort: warn and proceed. The `--force`
+   flag on `am session rm` skips the confirmation prompt only; cleanup failures are always
+   warnings, never hard errors.
+
+3. **Multi-session slug collision:** When the user is inside one of the repos with the
+   conflicting slug, resolve to that repo's session (no error). When the user is outside
+   all matching repos (or uses `--repo` pointing elsewhere), error and list the matching
+   repos with a hint to use `--repo`.
+
+4. **`am list --all` REPO column:** Abbreviate home directory as `~` (e.g.,
+   `~/src/project` instead of `/home/user/src/project`). Full absolute paths are used
+   internally; the abbreviation is display-only.
+
+---
+
+## Use-Cases
+
+### UC-1: `am init` — initialize a repo (updated behavior)
+
+**Actor:** Developer running `am` in a git or jj repo for the first time.
+
+**Preconditions:** Current directory is inside a git or jj repo; `am` binary is on `$PATH`.
+
+**Main flow:**
+1. Developer runs `am init`.
+2. `am` calls `find_repo_root()` to locate `<repo_root>`.
+3. `am` creates `<repo_root>/.am/` if it does not exist.
+4. If `<repo_root>/.am/config.toml` does not exist, `am` writes the default commented-out
+   template (unchanged from current `write_defaults`). Prints `Created .am/config.toml`.
+5. If `<repo_root>/.am/config.toml` already exists, prints `.am/config.toml already
+   exists, skipping`.
+6. `am` inspects `<repo_root>/.gitignore`:
+   a. If `.am/worktrees/` or `.am/worktrees` is already present: prints
+      `.am/worktrees/ already in .gitignore, skipping`.
+   b. Otherwise: appends `.am/worktrees/` to `.gitignore`. Prints `Added .am/worktrees/ to
+      .gitignore`.
+   c. If `.am/` or `.am` is present (old-style): prints advisory `Note: .am/ is already in
+      .gitignore; .am/config.toml is now committable — you may want to narrow this to
+      .am/worktrees/ instead.`
+7. Prints `am initialized. Run 'am start <slug>' to create your first session.`
+
+**Alternative flows:**
+- If `.gitignore` does not exist: create it and append `.am/worktrees/`.
+
+**Exception flows:**
+- File system error writing `.am/` or `.gitignore`: propagate as `IoError`; do not print
+  success message.
+- `find_repo_root()` returns `NotInRepo`: print `error: not in a git or jj repository`
+  and exit non-zero.
+
+**Postconditions:**
+- `.am/config.toml` exists.
+- `.am/worktrees/` is listed in `.gitignore`.
+- `.am/sessions.json` does NOT exist (no longer created by `am init`).
+- `.am/gitconfig` does NOT exist (no longer created by `am init`).
+
+**Business rules:**
+- `am init` is idempotent: safe to re-run in an already-initialized repo.
+- The global sessions file (`$XDG_STATE_HOME/am/sessions.json`) is NOT created by `am
+  init`; it is created lazily on first `am start`.
+
+---
+
+### UC-2: `am start <slug>` — start a session (updated behavior)
+
+**Actor:** Developer inside an initialized repo.
+
+**Preconditions:**
+- Current directory resolves to a repo root.
+- `.am/config.toml` may or may not exist (optional; defaults apply if absent).
+- Global sessions file may or may not exist (created lazily).
+
+**Main flow:**
+1. `am start feat` resolves `<repo_root>` and `vcs` via `find_repo_root()`.
+2. Load sessions from the global store: `load_sessions_global()` reads
+   `$XDG_STATE_HOME/am/sessions.json`.
+3. **Migration check:** if `<repo_root>/.am/sessions.json` exists, run
+   `migrate_sessions(repo_root)` (see UC-6) before proceeding.
+4. Filter sessions by `repo_root` to check for slug collision.
+5. If `feat` already exists in the global store for this `repo_root`: return
+   `SlugAlreadyExists("feat")`.
+6. Load config (`config::load_with_global`).
+7. **Gitconfig generation:** call `read_git_config("user.name")` and
+   `read_git_config("user.email")`; write the result to
+   `$XDG_STATE_HOME/am/gitconfig` as:
+   ```
+   [user]
+       name = <name>
+       email = <email>
+   ```
+   If both values are empty, write an empty `[user]` block (not an error; git behaves the
+   same).
+8. If containers are enabled and `container.gitconfig` is not set, the mount source for
+   gitconfig is now `$XDG_STATE_HOME/am/gitconfig` (not `<repo_root>/.am/gitconfig`).
+9. Complete the existing container/tmux/worktree flow unchanged.
+10. Build a `Session` record with the new `repo_root` field set to the absolute
+    `<repo_root>` path.
+11. Write the session record to the global store: `add_session_global(session)`.
+
+**Gitconfig path check (replaces old `.am/gitconfig` existence check):**
+- Step 2 of the existing preflight check currently errors when `.am/gitconfig` does not
+  exist and `container.gitconfig` is not set. After this change, `am start` generates the
+  gitconfig unconditionally at step 7, so this preflight check is removed entirely. If
+  `$XDG_STATE_HOME/am/` cannot be created, an `IoError` is returned before any side
+  effects.
+
+**Alternative flows:**
+- If `container.gitconfig` is explicitly set: use that path (unchanged); skip step 7's
+  gitconfig generation (or generate anyway — it is cheap and harmless).
+
+**Exception flows:**
+- `find_repo_root()` fails: `NotInRepo` error.
+- `$XDG_STATE_HOME` cannot be determined (no `HOME`): return a clear error `cannot
+  determine XDG_STATE_HOME: HOME is not set`.
+- `git config get user.name` fails or returns empty: write the gitconfig with an empty
+  name/email; do not abort.
+- Global sessions file cannot be written: return `IoError`.
+
+**Postconditions:**
+- Session record exists in `$XDG_STATE_HOME/am/sessions.json` with `repo_root` = absolute
+  path of the repo.
+- `$XDG_STATE_HOME/am/gitconfig` reflects the current user's git identity.
+- Worktree, tmux window, and container are created as before.
+
+**Business rules:**
+- Slug uniqueness is scoped to `repo_root`: the same slug may exist in two different
+  repos' sessions without conflict.
+- The session record's `repo_root` field must be an absolute, canonical path (resolved via
+  `std::fs::canonicalize` or equivalent).
+
+---
+
+### UC-3: `am list` — list sessions for current repo (updated behavior)
+
+**Actor:** Developer inside a repo.
+
+**Preconditions:** Current directory is inside a git or jj repo.
+
+**Main flow:**
+1. `am list` calls `find_repo_root()`.
+2. **Migration check:** if `<repo_root>/.am/sessions.json` exists, run `migrate_sessions`.
+3. Load all sessions from global store.
+4. Filter to sessions where `session.repo_root == <repo_root>`.
+5. If no sessions remain after filtering: print `No active sessions. Run 'am start
+   <slug>' to begin.`
+6. Otherwise print the existing tabular output (SLUG, CONTAINER, AUTO, WORKTREE, WINDOW,
+   CREATED — unchanged columns).
+
+**Alternative flows:**
+- `am list --all`: skip `find_repo_root()`; load all sessions from global store; show all
+  records regardless of `repo_root`. Add a REPO column (see UC-4).
+
+**Exception flows:**
+- `find_repo_root()` fails when `--all` is NOT passed: return `NotInRepo` error.
+- `find_repo_root()` fails when `--all` IS passed: proceed without filtering — `--all`
+  does not require a repo context.
+
+**Postconditions:** None (read-only).
+
+**Business rules:**
+- `am list` (no flag) without an `--all` flag requires a repo context.
+- `am list` never shows stale records in the default (scoped) view because stale means
+  the `repo_root` no longer exists; if the user is running `am` from within the repo, it
+  exists by definition.
+
+---
+
+### UC-4: `am list --all` — list sessions across all repos
+
+**Actor:** Developer, possibly outside any repo.
+
+**Preconditions:** None — can be run from any directory.
+
+**Main flow:**
+1. Load all sessions from global store.
+2. For each session, check if `session.repo_root` path exists on disk.
+   - If it does not exist: mark session as stale.
+3. Sort sessions: non-stale first (by `repo_root` alphabetically, then by `created_at`),
+   stale last.
+4. Print tabular output with columns: REPO, SLUG, CONTAINER, AUTO, WORKTREE, WINDOW,
+   CREATED, STATUS.
+   - STATUS is blank for live sessions; `stale` for sessions whose `repo_root` is gone.
+   - REPO shows the basename of `repo_root` by default; full path when the terminal is wide
+     enough or a `--wide` flag is supplied. (Implementation note: for the initial
+     implementation, always show full path and accept that the table may wrap on narrow
+     terminals.)
+5. If no sessions in global store: print `No sessions found across any repo.`
+
+**Exception flows:**
+- Global sessions file does not exist: treat as empty, print the empty message.
+
+**Postconditions:** None.
+
+**Business rules:**
+- A session is stale when `std::path::Path::exists(session.repo_root)` returns `false`.
+- Stale sessions are shown but not automatically removed; the user must run `am session rm`
+  explicitly.
+
+---
+
+### UC-5: `am session rm <slug>` — remove a session record
+
+**Actor:** Developer cleaning up stale or orphaned session records.
+
+**Preconditions:** A session with the given slug exists in the global store, either for the
+current repo or (with `--repo`) for a specified repo.
+
+**Main flow:**
+1. Developer runs `am session rm feat` from inside a repo, or
+   `am session rm feat --repo /path/to/repo` from anywhere.
+2. Resolve the repo root:
+   - With `--repo <path>`: use the provided path (validate it is absolute or resolve it to
+     absolute; the path need not exist on disk — this command is for cleanup).
+   - Without `--repo`: call `find_repo_root()` as usual.
+3. Load all sessions from global store.
+4. Find session with matching slug and `repo_root`. If not found: return
+   `SlugNotFound("feat")`.
+5. **Confirmation prompt** (unless `--force`):
+   ```
+   Remove session 'feat' from <repo_root>? [y/N]
+   ```
+   If user enters anything other than `y`/`Y`: print `Aborted.` and exit 0.
+6. **Best-effort cleanup** (errors logged as warnings, not failures):
+   a. If `session.container` is set: attempt `stop_container` and `remove_container` using
+      the recorded runtime. Log any error as `warning: container cleanup failed: <err>`.
+   b. If tmux window name is known: attempt `kill_window(session.tmux.tmux_window)`. Log
+      any error as `warning: tmux cleanup failed: <err>`.
+   c. Note: no worktree removal is attempted — `am session rm` is for orphaned records
+      where the worktree may already be gone. If the user wants worktree removal, they
+      should use `am destroy` instead.
+7. Remove the session record from the global store: `remove_session_global(repo_root, slug)`.
+8. Print `Removed session 'feat'.`
+
+**Alternative flows:**
+- `--force`: skip the confirmation prompt; proceed directly to step 6.
+- Stale session (repo no longer exists): proceed normally — the record is still removable
+  even when `repo_root` is gone.
+
+**Exception flows:**
+- Session not found: `SlugNotFound("feat")`.
+- Global sessions file write fails: `IoError`.
+- `find_repo_root()` fails (no repo context, no `--repo`): `NotInRepo`.
+
+**Postconditions:**
+- Session record is removed from the global store.
+- Container and tmux window are stopped/removed on a best-effort basis.
+
+**Business rules:**
+- `am session rm` does NOT remove the git worktree or jj workspace. It is for registry
+  cleanup only. If the worktree is still present, the user should use `am destroy` instead.
+- If multiple sessions share the same slug across different repos (possible in the global
+  store) and `--repo` is not given:
+  a. If the user is inside one of the matching repos (i.e., `find_repo_root()` succeeds
+     and matches one of the sessions' `repo_root` values): resolve to that repo's session
+     without error.
+  b. Otherwise, print:
+     ```
+     error: slug 'feat' exists in multiple repos:
+       /path/to/repo-a
+       /path/to/repo-b
+     Use --repo <path> to specify which one.
+     ```
+     and exit non-zero.
+
+---
+
+### UC-6: Migration — transparent upgrade from per-repo sessions
+
+**Actor:** `am` (automatic, triggered by any command that loads sessions for a specific repo).
+
+**Preconditions:** `<repo_root>/.am/sessions.json` exists (old-style layout).
+
+**Main flow (called from `load_sessions_for_repo` or before any session read):**
+1. Detect `<repo_root>/.am/sessions.json`.
+2. Parse the old file's `sessions` array.
+3. For each session record, add the `repo_root` field (set to the current `<repo_root>`).
+4. Merge into the global store: for each record, if a session with the same `repo_root` +
+   `slug` does not already exist, append it; if it does exist, skip (no overwrite).
+5. Delete `<repo_root>/.am/sessions.json`.
+6. Print to stderr: `Migrated N session(s) from .am/sessions.json to global store.`
+   (Use stderr so the message does not break scripts parsing `am list` stdout.)
+
+**Exception flows:**
+- Old file is malformed JSON: print a warning to stderr (`warning: could not parse
+  .am/sessions.json for migration: <err> — leaving file in place`); do NOT delete the old
+  file; do NOT abort the command in progress.
+- Global store write fails: propagate `IoError`; do NOT delete the old file (leave it for
+  the next attempt).
+- Old file exists but is empty or has `{"sessions":[]}`: migrate zero records; delete the
+  old file silently.
+
+**Postconditions:**
+- `<repo_root>/.am/sessions.json` no longer exists (unless migration failed).
+- All former local sessions appear in the global store with `repo_root` set.
+
+**Business rules:**
+- Migration is idempotent: re-running against the same old file (if it was not deleted due
+  to a write error) must not create duplicate records.
+- Migration must not block the command that triggered it. If the global store cannot be
+  written, the command should still attempt to proceed using the old file's data for the
+  current invocation (best-effort degraded mode). This avoids a scenario where a write
+  failure causes `am start` or `am list` to fail completely.
+
+---
+
+## Data Model
+
+### New field on `Session`
+
+```rust
+pub struct Session {
+    pub slug: String,
+    pub created_at: DateTime<Utc>,
+    #[serde(default)]
+    pub auto: bool,
+    /// Absolute path of the repository this session belongs to.
+    /// Added for global state; records without this field (migrated from the old per-repo
+    /// file) must have it populated by the migration path before writing to the global store.
+    pub repo_root: PathBuf,
+    #[serde(flatten)]
+    pub vcs: VcsMetadata,
+    #[serde(flatten)]
+    pub tmux: TmuxMetadata,
+    pub container: Option<SessionContainer>,
+}
+```
+
+`repo_root` uses `#[serde(default)]` is **not** appropriate here — every record in the
+global store must have `repo_root`. However, for backward-compatibility when reading old
+per-repo files during migration, parse into a temporary struct that allows a missing
+`repo_root`, then populate it before writing to the global store.
+
+### Global sessions file location
+
+```
+$XDG_STATE_HOME/am/sessions.json      (when XDG_STATE_HOME is set)
+~/.local/state/am/sessions.json       (fallback)
+```
+
+Helper function (analogous to `config::global_config_path()`):
+
+```rust
+pub fn global_sessions_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/state")))?;
+    Some(base.join("am").join("sessions.json"))
+}
+```
+
+### Global gitconfig location
+
+```
+$XDG_STATE_HOME/am/gitconfig
+~/.local/state/am/gitconfig
+```
+
+This file is regenerated at each `am start` and is transient (never version-controlled).
+
+### Uniqueness constraint
+
+Within the global sessions file, the pair `(repo_root, slug)` must be unique. The
+`add_session_global` function enforces this.
+
+### Indexes needed
+
+No database — JSON file is small. However, the session-loading functions that filter by
+`repo_root` iterate linearly over all records, which is acceptable for the expected scale
+(tens of sessions per machine, not thousands).
+
+---
+
+## API Design (internal Rust API)
+
+These are the function signatures the engineer must implement or update. There is no HTTP
+API. The session module is the primary touch point.
+
+### New functions in `session.rs`
+
+```rust
+/// Resolve the global sessions file path.
+/// Returns None only if neither XDG_STATE_HOME nor HOME is set.
+pub fn global_sessions_path() -> Option<PathBuf>
+
+/// Load all sessions from the global store.
+pub fn load_all_sessions() -> Result<Vec<Session>>
+
+/// Load sessions belonging to a specific repo (filters by repo_root).
+/// Returns an empty Vec if the global file does not exist yet.
+pub fn load_sessions_for_repo(repo_root: &Path) -> Result<Vec<Session>>
+
+/// Add a session to the global store.
+/// Errors with SlugAlreadyExists if (repo_root, slug) already exists.
+pub fn add_session_global(session: Session) -> Result<()>
+
+/// Remove a session from the global store by (repo_root, slug).
+/// Errors with SlugNotFound if not found.
+pub fn remove_session_global(repo_root: &Path, slug: &str) -> Result<()>
+
+/// Migrate sessions from an old per-repo file into the global store.
+/// Deletes the old file on success. Idempotent.
+/// Returns the number of records migrated (0 if none or already migrated).
+pub fn migrate_sessions(repo_root: &Path) -> Result<usize>
+```
+
+### Deprecated / removed functions in `session.rs`
+
+The existing `load_sessions(repo_root)`, `save_sessions(repo_root, sessions)`, and
+`add_session(repo_root, session)` operate on the per-repo file. These are replaced by the
+global equivalents above. The old functions should be retained temporarily with a
+`#[deprecated]` attribute and removed once all call sites are updated. `remove_session`
+becomes `remove_session_global`.
+
+### Changes to `config.rs`
+
+Add a new public function (symmetric with `global_config_path`):
+
+```rust
+/// Returns the global state directory: $XDG_STATE_HOME/am or ~/.local/state/am.
+pub fn global_state_dir() -> Option<PathBuf>
+```
+
+This is used by both `session.rs` (for `sessions.json`) and `main.rs` (for gitconfig).
+
+### Changes to `main.rs`
+
+**`cmd_init`:** Remove the blocks that create `sessions.json` and `gitconfig`. Update
+`.gitignore` logic to target `.am/worktrees/` instead of `.am/`.
+
+**`cmd_start`:**
+- Replace `session::load_sessions(&repo_root)` with `session::load_sessions_for_repo(&repo_root)`.
+- Add migration check before the slug collision check.
+- Remove the `.am/gitconfig` existence check.
+- Add gitconfig generation step (write to `global_state_dir()/gitconfig`).
+- Update the gitconfig mount path used in `plan_image` / `plan_devcontainer`.
+- Replace `session::add_session(&repo_root, new_session)` with
+  `session::add_session_global(new_session)` (where `new_session` now carries `repo_root`).
+
+**`cmd_list`:**
+- Add `--all` flag (boolean) to the `List` variant in `cli.rs`.
+- If `--all`: call `session::load_all_sessions()`; skip `find_repo_root()`.
+- Otherwise: call `session::load_sessions_for_repo(&repo_root)` after migration check.
+- Add STATUS column to `--all` output.
+
+**`cmd_destroy`:**
+- Replace `session::load_sessions(&repo_root)` with `session::load_sessions_for_repo`.
+- Replace `session::remove_session(&repo_root, slug)` with `session::remove_session_global`.
+
+**`cmd_attach` and `cmd_run`:**
+- Same load/find replacement as `cmd_destroy`.
+
+**New `cmd_session_rm`:** Implement the `am session rm` handler.
+
+### Changes to `cli.rs`
+
+```rust
+#[derive(Subcommand)]
+pub enum Commands {
+    // ... existing variants unchanged ...
+
+    /// List sessions (default: current repo; --all shows all repos)
+    List {
+        #[arg(long, help = "Show sessions from all repos")]
+        all: bool,
+    },
+
+    /// Manage session records in the global store
+    Session {
+        #[command(subcommand)]
+        command: SessionCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum SessionCommands {
+    /// Remove a session record (and attempt container/tmux cleanup)
+    Rm {
+        #[arg(value_parser = validate_slug)]
+        slug: String,
+        /// Repository root containing this session (required when not inside a repo,
+        /// or when the slug exists in multiple repos)
+        #[arg(long)]
+        repo: Option<PathBuf>,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        force: bool,
+    },
+}
+```
+
+Note: `List` changes from a unit variant to a struct variant, which changes how it is
+matched in `run()`. All callers must be updated.
+
+---
+
+## Config Layering and Committable `.am/config.toml`
+
+With `.am/config.toml` now committable, the existing config precedence order is important:
+
+```
+defaults → global config → project config → env vars → CLI flags
+```
+
+This is the conventional "most-specific wins" pattern (same as git). A team commits
+project-level settings (e.g., `agent`, `container.mode`, `devcontainer` options) in
+`.am/config.toml`. Individual developers set personal preferences (e.g.,
+`container.runtime`, `container.ssh`) in their global `~/.config/am/config.toml`. If a
+user needs to override a committed project setting, env vars (`AM_*`) and CLI flags serve
+as the escape hatch — no config file changes required.
+
+### Removal of `vcs` config setting
+
+The `vcs` field in `[defaults]` is removed from the config schema entirely.
+`find_repo_root()` already auto-detects VCS by checking for `.jj/` (preferred) then
+`.git/` on disk. The config value was parsed but never consumed by any command — it is
+dead code. Removing it avoids the problem of a committed config forcing a VCS choice that
+doesn't match a developer's actual setup (e.g., a jj user cloning a repo whose committed
+config says `vcs = "git"`).
+
+**Changes:**
+- Remove `vcs` from `Config`, `FileConfig`, `Vcs` enum references in config parsing
+- Remove the `vcs` line from `write_defaults()` and `global_config_template()`
+- Remove the `AM_VCS` env var handling if present
+- Keep `Vcs` enum itself (used by `find_repo_root()` return type and worktree operations)
+
+---
+
+## Implementation Tasks
+
+### backend-engineer
+
+- [ ] **`config.rs`:** Remove `vcs` from `Config` struct, `FileConfig` struct,
+  `apply_file_config`, `write_defaults`, and `global_config_template`. Keep the `Vcs` enum
+  (still used by `find_repo_root` and worktree operations).
+- [ ] **`config.rs`:** Add `global_state_dir() -> Option<PathBuf>` using
+  `$XDG_STATE_HOME` (falling back to `~/.local/state`). This is the single source of
+  truth for the state directory location.
+- [ ] **`session.rs`:** Add `repo_root: PathBuf` to `Session`. Use `#[serde(default)]`
+  on a temporary migration-only struct (not on `Session` itself) so that records without
+  `repo_root` can be read during migration and then written with it populated.
+- [ ] **`session.rs`:** Implement `global_sessions_path()`.
+- [ ] **`session.rs`:** Implement `load_all_sessions()`, `load_sessions_for_repo()`,
+  `add_session_global()`, `remove_session_global()`, `migrate_sessions()`. Follow the
+  same file-write pattern as existing `save_sessions` (pretty-print JSON, atomic where
+  possible).
+- [ ] **`session.rs`:** Mark old `load_sessions`, `save_sessions`, `add_session`,
+  `remove_session` as `#[deprecated]`.
+- [ ] **`main.rs` — `cmd_init`:** Remove `sessions.json` creation. Remove `gitconfig`
+  creation. Change `.gitignore` logic: target `.am/worktrees/`, detect old `.am/` entry
+  and print advisory.
+- [ ] **`main.rs` — `cmd_start`:** Add migration call. Remove `.am/gitconfig` preflight
+  check. Add gitconfig generation step writing to `global_state_dir()/gitconfig`. Update
+  gitconfig mount source. Switch to `load_sessions_for_repo` and `add_session_global`.
+  Set `repo_root` on the new `Session` record.
+- [ ] **`main.rs` — `cmd_list`:** Handle new `List { all }` variant. Branch on `all` for
+  load and display. Add REPO and STATUS columns for `--all` output. Add stale detection.
+- [ ] **`main.rs` — `cmd_destroy`:** Switch to `load_sessions_for_repo` and
+  `remove_session_global`.
+- [ ] **`main.rs` — `cmd_attach` / `cmd_run`:** Switch to `load_sessions_for_repo`.
+- [ ] **`main.rs` — `cmd_session_rm`:** Implement new handler (UC-5). Add migration check.
+- [ ] **`cli.rs`:** Convert `List` from unit to struct variant. Add `Session`/`SessionCommands`
+  tree. Wire new commands in `run()`.
+- [ ] **`container.rs` / `plan_image` / `plan_devcontainer`:** Update gitconfig mount
+  source to use `global_state_dir()/gitconfig` when `container.gitconfig` is not set.
+- [ ] **`error.rs`:** Add `GlobalStateDirNotFound` variant for when neither
+  `XDG_STATE_HOME` nor `HOME` is set. Message:
+  `"cannot determine state directory: neither XDG_STATE_HOME nor HOME is set"`.
+
+### integration-tester
+
+- [ ] Test that `vcs` is no longer accepted in config files (or is silently ignored).
+- [ ] Test `am init` no longer creates `sessions.json` or `gitconfig`.
+- [ ] Test `am init` writes `.am/worktrees/` (not `.am/`) to `.gitignore`.
+- [ ] Test `am init` prints advisory when old `.am/` entry already exists.
+- [ ] Test `am start` creates session in `$XDG_STATE_HOME/am/sessions.json`.
+- [ ] Test `am start` session record has `repo_root` set to the canonical repo root path.
+- [ ] Test `am start` generates `$XDG_STATE_HOME/am/gitconfig`.
+- [ ] Test `am list` returns only sessions for the current repo.
+- [ ] Test `am list --all` returns sessions from all repos, including stale.
+- [ ] Test `am list --all` marks session as stale when `repo_root` does not exist.
+- [ ] Test migration: running any command against a repo with `.am/sessions.json` migrates
+  records to global store and deletes the old file.
+- [ ] Test migration idempotency: re-running when old file is gone does nothing.
+- [ ] Test migration with malformed old file: old file is left in place, command proceeds.
+- [ ] Test `am session rm feat` removes record from global store.
+- [ ] Test `am session rm feat --force` skips confirmation.
+- [ ] Test `am session rm feat --repo /path` works outside a repo.
+- [ ] Test `am session rm` with slug matching two repos errors and names both.
+- [ ] Test `am destroy` still works after migration.
+- [ ] Test `am attach`, `am run` still work after migration.
+- [ ] Test slug uniqueness is per-repo (same slug in two repos is allowed).
+- [ ] Unit tests for `global_sessions_path()` with and without `XDG_STATE_HOME`.
+- [ ] Unit tests for `migrate_sessions()` — zero records, non-zero records, duplicate guard.
+- [ ] Unit tests for `load_sessions_for_repo()` filtering.
+- [ ] Unit tests for `add_session_global()` — uniqueness enforcement on `(repo_root, slug)`.
+
+### code-reviewer
+
+- [ ] Verify `repo_root` is always stored as a canonical absolute path (not relative, not
+  with trailing slash).
+- [ ] Verify migration deletes the old file only after a successful global store write.
+- [ ] Verify `am session rm` leaves the worktree untouched.
+- [ ] Verify the stale check uses `Path::exists()` (not `metadata()`) for consistency.
+- [ ] Verify `cmd_list --all` does not call `find_repo_root()` (would fail outside a repo).
+- [ ] Verify `global_state_dir()` is the single source of truth — no other code constructs
+  `XDG_STATE_HOME` paths independently.
+- [ ] Verify old deprecated functions are not called anywhere after migration.
+- [ ] Check that the `(repo_root, slug)` uniqueness invariant is enforced at write time,
+  not just at session-start time (i.e., `add_session_global` checks, not only `cmd_start`).
+
+### documentation-writer
+
+- [ ] Update `docs/getting-started/` to remove the reference to `.am/` being gitignored
+  and add a note that `.am/config.toml` is now committable.
+- [ ] Update `docs/reference/` (config reference) to note that `sessions.json` has moved.
+- [ ] Add a new reference page or expand the existing one to document `am session rm` and
+  `am list --all`.
+- [ ] Update `SPEC.md` to reflect the new `.am/` directory layout (what is present,
+  what is absent).
+- [ ] Update `PLAN.md` to add this feature with its sub-tasks.
+- [ ] Update inline comments in `write_defaults` (the `config.toml` template) to remove
+  the note about `.am/sessions.json`, if any exists.
+
+---
+
+## Edge Cases and Considerations
+
+### Security
+
+- **`--repo <path>` in `am session rm`:** The provided path is used only for record
+  lookup, not for file operations against that path (the worktree is not touched). No path
+  traversal risk beyond what `find_repo_root()` already accepts.
+- **Global sessions file permissions:** Created with the user's `umask` (same as any other
+  file written by `am`). No special permissions needed — it contains only metadata about
+  the user's own sessions.
+- **Gitconfig at `$XDG_STATE_HOME/am/gitconfig`:** Contains the user's git identity
+  (name, email). This is not sensitive but should not be world-readable on multi-user
+  systems. The file is written with the user's `umask`; no explicit chmod is needed.
+
+### Performance
+
+- The global sessions file is read on every `am` invocation that involves session state.
+  At the expected scale (dozens of sessions), a full linear scan and JSON parse is
+  negligible. No caching or indexing is needed.
+
+### Race conditions
+
+- Two simultaneous `am start` commands in the same repo with the same slug will both pass
+  the initial slug check and then race to write the global store. The last write wins.
+  This is the same race that exists in the current per-repo sessions file. Fixing it
+  requires file locking, which is out of scope for this feature. Document as a known
+  limitation.
+
+### UX — error messages
+
+- When `global_sessions_path()` returns `None` (no `HOME`): `error: cannot determine
+  state directory: neither XDG_STATE_HOME nor HOME is set`.
+- When a user runs `am list` outside a repo without `--all`: `error: not in a git or jj
+  repository. Run 'am list --all' to see sessions from all repos.` (augment the existing
+  `NotInRepo` message in this context, or catch the error in `cmd_list` and re-wrap it).
+- When `am session rm` finds the slug in multiple repos: list both paths and instruct use
+  of `--repo`.
+
+### Backward compatibility
+
+- Old per-repo `sessions.json` files are migrated automatically; no user action required.
+- Sessions recorded before this change have no `repo_root` field. The migration assigns
+  `repo_root` from the repo where the file is found, which is correct.
+- If a user downgrades `am` after migration, `am list` returns an empty list (the old
+  `load_sessions` reads `<repo>/.am/sessions.json`, which no longer exists). Sessions are
+  not lost — they remain in the global file. Upgrading again restores visibility.
+
+### Scalability
+
+- One global file per machine. If a developer has 50 repos each with 10 sessions, the
+  global file has 500 records (~100 KB). JSON round-trip at this scale is well under 1 ms.
+  No concern.
+
+### Testing — environment isolation
+
+- Tests that write sessions must inject `XDG_STATE_HOME` via `std::env::set_var` and hold
+  the `ENV_MUTEX` (already used in `config.rs` tests) to prevent cross-test pollution.
+- Tests that exercise `global_sessions_path()` must save and restore `XDG_STATE_HOME` and
+  `HOME` using the existing `EnvGuard` pattern.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 
 fn validate_slug(s: &str) -> Result<String, String> {
@@ -59,8 +61,11 @@ pub enum Commands {
     /// Report what is and is not ready for a successful `am start`
     Doctor,
 
-    /// List all sessions
-    List,
+    /// List sessions (default: current repo; --all shows all repos)
+    List {
+        #[arg(long, help = "Show sessions from all repos")]
+        all: bool,
+    },
 
     /// Attach tmux focus to an existing session
     Attach {
@@ -87,6 +92,28 @@ pub enum Commands {
 
     /// Print a global config template with all options and defaults to stdout
     GenerateConfig,
+
+    /// Manage session records in the global store
+    Session {
+        #[command(subcommand)]
+        command: SessionCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum SessionCommands {
+    /// Remove a session record (and attempt container/tmux cleanup)
+    Rm {
+        #[arg(value_parser = validate_slug)]
+        slug: String,
+        /// Repository root containing this session (required when not inside a repo,
+        /// or when the slug exists in multiple repos)
+        #[arg(long)]
+        repo: Option<PathBuf>,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        force: bool,
+    },
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,7 +200,6 @@ impl Default for DevcontainerConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-    pub vcs: Vcs,
     pub agent: Option<String>,
     /// Per-agent settings (image, etc.). Compiled-in defaults for known agents.
     pub agents: HashMap<String, AgentSettings>,
@@ -242,7 +241,6 @@ fn default_agent_images() -> HashMap<String, AgentSettings> {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            vcs: Vcs::Git,
             agent: None,
             agents: default_agent_images(),
             tmux: TmuxConfig::default(),
@@ -282,7 +280,6 @@ pub fn resolve_image<'a>(agent: Option<&str>, cfg: &'a Config) -> Option<&'a str
 
 #[derive(Debug, Deserialize, Default)]
 struct FileDefaults {
-    vcs: Option<Vcs>,
     agent: Option<String>,
 }
 
@@ -364,7 +361,6 @@ fn apply_opt_string(target: &mut Option<String>, value: Option<String>) {
 }
 
 fn apply_file_config(base: &mut Config, file: FileConfig) {
-    apply_opt(&mut base.vcs, file.defaults.vcs);
     apply_opt_string(&mut base.agent, file.defaults.agent);
 
     // Merge agents: file entries extend/override the compiled-in defaults.
@@ -442,6 +438,16 @@ fn dirs_path() -> Option<PathBuf> {
     Some(base.join("am"))
 }
 
+/// Returns the global state directory: `$XDG_STATE_HOME/am` if set,
+/// otherwise `~/.local/state/am`.
+/// Returns `None` only if neither `XDG_STATE_HOME` nor `HOME` is set.
+pub fn global_state_dir() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/state")))?;
+    Some(base.join("am"))
+}
+
 /// Write the default project config file at `path` (creates parent directories as needed).
 /// The file is written as a fully-commented-out template so it never silently overrides
 /// global or compiled-in defaults.
@@ -455,7 +461,6 @@ pub fn write_defaults(path: &Path) -> Result<()> {
 # Run `am generate-config` to see the full global config template with all options documented.
 
 [defaults]
-# vcs = "git"            # "git" | "jj"
 # agent = "claude"       # agent to launch, e.g. "claude" | "copilot" — also selects the container image
 
 # Override the container image for a specific agent (built-in defaults shown):
@@ -500,7 +505,7 @@ pub fn global_config_template() -> &'static str {
 # Precedence (highest wins): CLI flags > environment variables > project config (.am/config.toml) > global config
 #
 # Environment variable overrides:
-#   AM_VCS, AM_AGENT
+#   AM_AGENT
 #   AM_TMUX_AGENT_PANE, AM_TMUX_SPLIT, AM_TMUX_SPLIT_PERCENT
 #   AM_CONTAINER_ENABLED, AM_CONTAINER_MODE, AM_CONTAINER_RUNTIME, AM_CONTAINER_IMAGE,
 #   AM_CONTAINER_AGENT, AM_CONTAINER_NETWORK, AM_CONTAINER_USER
@@ -508,7 +513,6 @@ pub fn global_config_template() -> &'static str {
 #   AM_DEVCONTAINER_BIN (path to the `devcontainer` CLI)
 
 [defaults]
-vcs = "git"            # "git" | "jj"
 agent = "claude"       # agent to launch; also selects the container image via [agents.<name>]
 
 # Per-agent configuration. These are the compiled-in defaults — override here if needed.
@@ -575,13 +579,6 @@ skip_lifecycle = false         # skip postCreateCommand and the other in-contain
 /// physical constraints (e.g. split_percent must be 1–99) return an error
 /// rather than silently falling back, matching the behaviour of TOML parsing.
 fn apply_env_vars(config: &mut Config) -> Result<()> {
-    if let Ok(val) = std::env::var("AM_VCS") {
-        match val.as_str() {
-            "git" => config.vcs = Vcs::Git,
-            "jj" => config.vcs = Vcs::Jj,
-            _ => {}
-        }
-    }
     if let Ok(val) = std::env::var("AM_AGENT") {
         if !val.is_empty() {
             config.agent = Some(val);
@@ -795,7 +792,6 @@ mod tests {
         let config =
             load_with_global(Some(&nonexistent_global), Some(&nonexistent_project)).unwrap();
 
-        assert_eq!(config.vcs, Vcs::Git);
         assert!(config.agent.is_none());
         assert_eq!(config.tmux.split_percent, 50);
         assert!(config.container.enabled);
@@ -1069,6 +1065,45 @@ image = "myorg/am-claude:project"
                 .and_then(|a| a.image.as_deref()),
             Some("ghcr.io/dstanek/am-copilot-minimal:latest")
         );
+    }
+
+    #[test]
+    fn global_state_dir_uses_xdg_state_home() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        let xdg_dir = tmp.path().join("xdg_state");
+        std::env::set_var("XDG_STATE_HOME", &xdg_dir);
+        std::env::remove_var("HOME");
+
+        let path = global_state_dir();
+        assert_eq!(path, Some(xdg_dir.join("am")));
+    }
+
+    #[test]
+    fn global_state_dir_falls_back_to_home_local_state() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::remove_var("XDG_STATE_HOME");
+        std::env::set_var("HOME", tmp.path());
+
+        let path = global_state_dir();
+        assert_eq!(
+            path,
+            Some(tmp.path().join(".local").join("state").join("am"))
+        );
+    }
+
+    #[test]
+    fn global_state_dir_returns_none_without_home_or_xdg() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        std::env::remove_var("XDG_STATE_HOME");
+        std::env::remove_var("HOME");
+
+        let path = global_state_dir();
+        assert_eq!(path, None);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1184,6 +1184,9 @@ env = ["--rm"]
 
     #[test]
     fn split_percent_out_of_range_in_toml_fails() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["AM_TMUX_SPLIT_PERCENT"]);
+        std::env::remove_var("AM_TMUX_SPLIT_PERCENT");
         let tmp = TempDir::new().unwrap();
         let project = write_toml(
             tmp.path(),
@@ -1202,6 +1205,9 @@ split_percent = 100
 
     #[test]
     fn split_percent_zero_in_toml_fails() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["AM_TMUX_SPLIT_PERCENT"]);
+        std::env::remove_var("AM_TMUX_SPLIT_PERCENT");
         let tmp = TempDir::new().unwrap();
         let project = write_toml(
             tmp.path(),

--- a/src/container.rs
+++ b/src/container.rs
@@ -100,7 +100,7 @@ pub struct ContainerMounts {
     pub worktree_host: PathBuf,
     pub vcs_host: PathBuf,                   // .git dir (git) or .jj dir (jj)
     pub colocated_git_host: Option<PathBuf>, // .git for colocated jj+git repos
-    pub gitconfig_host: PathBuf,             // .am/gitconfig (or override)
+    pub gitconfig_host: PathBuf,             // $XDG_STATE_HOME/am/gitconfig (or override)
     pub ssh_host: PathBuf,                   // ~/.ssh
     pub agent_auth: Vec<AgentAuthMount>,
     /// Home directory inside the container. Derived from the configured container user
@@ -255,6 +255,7 @@ pub fn resolve_mounts(
     };
     let gitconfig_host = gitconfig
         .map(|p| p.to_path_buf())
+        .or_else(|| crate::config::global_state_dir().map(|d| d.join("gitconfig")))
         .unwrap_or_else(|| repo_root.join(".am").join("gitconfig"));
     let ssh_host = ssh
         .map(|p| p.to_path_buf())
@@ -914,7 +915,11 @@ mod tests {
 
         assert_eq!(mounts.worktree_host, repo_root.join(".am/worktrees/feat"));
         assert_eq!(mounts.vcs_host, repo_root.join(".git"));
-        assert_eq!(mounts.gitconfig_host, repo_root.join(".am/gitconfig"));
+        // When no explicit gitconfig is given, falls back to global state dir.
+        assert_eq!(
+            mounts.gitconfig_host,
+            tmp.path().join(".local/state/am/gitconfig")
+        );
         assert_eq!(mounts.ssh_host, tmp.path().join(".ssh"));
         assert!(mounts.agent_auth.is_empty());
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -240,31 +240,36 @@ fn check_project_setup(report: &mut Report, repo_root: &Path, cfg: &Config) {
         format!("initialized at {}", am_dir.display()),
     ));
 
-    // cmd_start requires a gitconfig when containers are on, unless one is configured
-    // elsewhere — mirror that condition exactly rather than always demanding the file.
-    let gitconfig = cfg
-        .container
-        .gitconfig
-        .clone()
-        .unwrap_or_else(|| am_dir.join("gitconfig"));
-    if gitconfig.exists() {
+    // am start generates a gitconfig from git config at session start time.
+    // Check that git identity is available so the generated gitconfig will be useful.
+    let has_name = std::process::Command::new("git")
+        .args(["config", "--global", "user.name"])
+        .output()
+        .ok()
+        .is_some_and(|o| o.status.success() && !o.stdout.is_empty());
+    let has_email = std::process::Command::new("git")
+        .args(["config", "--global", "user.email"])
+        .output()
+        .ok()
+        .is_some_and(|o| o.status.success() && !o.stdout.is_empty());
+    if has_name && has_email {
         report.checks.push(Check::ok(
             PROJECT,
             "git identity",
-            format!("{}", gitconfig.display()),
+            "user.name and user.email configured",
         ));
     } else if cfg.container.enabled {
-        report.checks.push(Check::fail(
+        report.checks.push(Check::warn(
             PROJECT,
             "git identity",
-            format!("{} not found", gitconfig.display()),
-            "run 'am init', or set container.gitconfig to an existing file",
+            "user.name or user.email not set in git config",
+            "run 'git config --global user.name \"Your Name\"' and 'git config --global user.email you@example.com'",
         ));
     } else {
         report.checks.push(Check::warn(
             PROJECT,
             "git identity",
-            format!("{} not found", gitconfig.display()),
+            "user.name or user.email not set in git config",
             "not required while container.enabled = false",
         ));
     }
@@ -778,20 +783,11 @@ mod tests {
     fn initialised_project_reports_ok() {
         let tmp = TempDir::new().unwrap();
         std::fs::create_dir_all(tmp.path().join(".am")).unwrap();
-        std::fs::write(tmp.path().join(".am").join("gitconfig"), "").unwrap();
         let report = run(Some((tmp.path(), Vcs::Git)), None);
         assert_eq!(find(&report, ".am/").status, Status::Ok);
-        assert_eq!(find(&report, "git identity").status, Status::Ok);
-    }
-
-    #[test]
-    fn missing_gitconfig_fails_only_because_containers_need_it() {
-        let tmp = TempDir::new().unwrap();
-        std::fs::create_dir_all(tmp.path().join(".am")).unwrap();
-        let report = run(Some((tmp.path(), Vcs::Git)), None);
-        let check = find(&report, "git identity");
-        assert_eq!(check.status, Status::Fail);
-        assert!(check.hint.as_deref().unwrap().contains("am init"));
+        // git identity check depends on the test runner's actual git config,
+        // so we only verify the check exists, not its status.
+        find(&report, "git identity");
     }
 
     // ── Agent ─────────────────────────────────────────────────────────────────

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,9 @@ pub enum AmError {
     #[error("config error: {0}")]
     ConfigError(String),
 
+    #[error("cannot determine state directory: neither XDG_STATE_HOME nor HOME is set")]
+    GlobalStateDirNotFound,
+
     #[error(transparent)]
     IoError(#[from] std::io::Error),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,9 @@ fn cmd_init() -> anyhow::Result<()> {
             .create(true)
             .append(true)
             .open(&gitignore_path)?;
+        if !gitignore_content.is_empty() && !gitignore_content.ends_with('\n') {
+            file.write_all(b"\n")?;
+        }
         file.write_all(b".am/worktrees/\n")?;
         println!("Added .am/worktrees/ to .gitignore");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,20 @@ mod tmux;
 mod worktree;
 
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
 use clap::Parser;
 use cli::{Cli, Commands, SessionCommands};
 use command::shell_quote;
+
+/// Build a stable, globally unique container name from a repo and session slug.
+fn container_name(repo_root: &Path, slug: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(repo_root.as_os_str().as_encoded_bytes());
+    let prefix: String = hash.iter().take(3).map(|b| format!("{b:02x}")).collect();
+    format!("am-{slug}-{prefix}")
+}
 
 fn main() {
     let cli = Cli::parse();
@@ -129,9 +137,12 @@ fn cmd_start(
 
     let sessions = session::load_sessions_for_repo(&repo_root)?;
 
-    if session::find_session(&sessions, slug).is_some() {
+    if sessions.iter().any(|s| s.slug == slug) {
         return Err(error::AmError::SlugAlreadyExists(slug.to_string()).into());
     }
+
+    let window_name = format!("am-{slug}");
+    let container_name = container_name(&repo_root, slug);
 
     // Load config
     let project_config_path = repo_root.join(".am").join("config.toml");
@@ -184,7 +195,7 @@ fn cmd_start(
             container::validate_agent_credentials(agent)?;
         }
         // Pre-emptively remove any leftover container from a previous run
-        container::remove_if_exists(&runtime, &format!("am-{slug}"));
+        container::remove_if_exists(&runtime, &container_name);
         Some(runtime)
     } else {
         None
@@ -198,7 +209,7 @@ fn cmd_start(
     let worktree_path = guard.path().to_path_buf();
 
     // ── Post-worktree preflight: the devcontainer config, if any ──────────────
-    let (container_cmd, session_container) = match runtime {
+    let (container_cmd, mut session_container) = match runtime {
         Some(ref runtime) => {
             let plan = plan_container(ContainerPlanInput {
                 slug,
@@ -211,13 +222,15 @@ fn cmd_start(
                 agent_name: effective_agent.as_deref(),
                 auto,
                 rebuild,
+                container_name: &container_name,
             })?;
             (Some(plan.cmd), Some(plan.session))
         }
         None => (None, None),
     };
-    let window_name = format!("am-{slug}");
-
+    if let Some(container) = &mut session_container {
+        container.container_name = Some(container_name.clone());
+    }
     // Pane assignment: split-window creates a new pane at index 1.
     // PaneSide::Right: agent in new pane (1), shell in original (0).
     // PaneSide::Left:  agent in original pane (0), shell in new pane (1).
@@ -227,11 +240,11 @@ fn cmd_start(
         config::PaneSide::Left => (0usize, 1usize, 100 - cfg.tmux.split_percent),
     };
 
-    if tmux::is_in_tmux() {
+    let tmux_window_id = if tmux::is_in_tmux() {
         // Create a dedicated window for the session instead of commandeering the
         // caller's current window. `new-window` opens both panes in the worktree
         // and switches focus to the new window automatically.
-        tmux::create_window(&window_name, &worktree_path)
+        let window_id = tmux::create_window(&window_name, &worktree_path)
             .map_err(|e| anyhow::anyhow!(
                 "{e}\nHint: a window named '{window_name}' may already exist — run 'am destroy {slug}' first"
             ))?;
@@ -244,7 +257,7 @@ fn cmd_start(
         let split_shell_cmd =
             split_window_shell_cmd(container_shell_cmd.as_deref(), agent_pane_idx);
         tmux::split_window(
-            &window_name,
+            &window_id,
             &worktree_path,
             &cfg.tmux.split,
             new_pane_percent,
@@ -255,17 +268,21 @@ fn cmd_start(
         })?;
         if let Some(ref cmd) = container_shell_cmd {
             if split_shell_cmd.is_none() {
-                tmux::send_keys(&tmux::get_pane_id(&window_name, agent_pane_idx), cmd)?;
+                tmux::send_keys(&tmux::get_pane_id(&window_id, agent_pane_idx), cmd)?;
             }
         } else if let Some(ref agent) = effective_agent {
-            tmux::send_keys(&tmux::get_pane_id(&window_name, agent_pane_idx), agent)?;
+            tmux::send_keys(&tmux::get_pane_id(&window_id, agent_pane_idx), agent)?;
         }
         // Both panes already open in the worktree (via `new-window -c`), so no cd
         // is needed. Keep focus on the shell pane.
-        tmux::select_pane(&tmux::get_pane_id(&window_name, shell_pane_idx))?;
+        tmux::select_pane(&tmux::get_pane_id(&window_id, shell_pane_idx))?;
+        Some(window_id)
     } else if container_cmd.is_none() {
         println!("Note: not inside tmux — no window opened. Run 'am attach {slug}' from inside tmux to open one.");
-    }
+        None
+    } else {
+        None
+    };
 
     let new_session = session::Session {
         slug: slug.to_string(),
@@ -277,9 +294,10 @@ fn cmd_start(
             worktree_path: worktree_path.clone(),
         },
         tmux: session::TmuxMetadata {
-            tmux_window: window_name,
-            agent_pane: tmux::get_pane_id(&format!("am-{slug}"), agent_pane_idx),
-            shell_pane: tmux::get_pane_id(&format!("am-{slug}"), shell_pane_idx),
+            tmux_window: window_name.clone(),
+            tmux_window_id: tmux_window_id.clone(),
+            agent_pane: tmux::get_pane_id(tmux_window_id.as_deref().unwrap_or(&window_name), agent_pane_idx),
+            shell_pane: tmux::get_pane_id(tmux_window_id.as_deref().unwrap_or(&window_name), shell_pane_idx),
             // Sessions now own a dedicated window; there is no prior window state
             // to restore on destroy. These remain for compatibility with records
             // written by older versions of `am`.
@@ -298,7 +316,7 @@ fn cmd_start(
             guard.commit();
             println!("Started session '{slug}'");
             println!("  worktree:  {}", worktree_path.display());
-            println!("  container: am-{slug}");
+            println!("  container: {container_name}");
             #[cfg(unix)]
             {
                 use std::os::unix::process::CommandExt;
@@ -333,7 +351,7 @@ fn cmd_start(
     println!("  worktree:  {}", worktree_path.display());
     println!("  branch:    am/{slug}");
     if let Some((mode, image)) = mode {
-        println!("  container: am-{slug}");
+        println!("  container: {container_name}");
         if mode == session::ContainerMode::Devcontainer {
             println!("  image:     {image} (from devcontainer.json)");
         }
@@ -356,6 +374,7 @@ struct ContainerPlanInput<'a> {
     agent_name: Option<&'a str>,
     auto: bool,
     rebuild: bool,
+    container_name: &'a str,
 }
 
 struct ContainerPlan {
@@ -377,6 +396,7 @@ fn plan_container(input: ContainerPlanInput) -> anyhow::Result<ContainerPlan> {
         agent_name,
         auto,
         rebuild,
+        container_name,
     } = input;
 
     // Discovery is relative to the worktree: the config is a checked-in, branch-specific
@@ -402,8 +422,10 @@ fn plan_container(input: ContainerPlanInput) -> anyhow::Result<ContainerPlan> {
     match config_path {
         Some(path) => plan_devcontainer(
             slug, repo_root, worktree, vcs, cfg, runtime, agent, agent_name, auto, rebuild, &path,
+            container_name,
         ),
-        None => plan_image(slug, repo_root, vcs, cfg, runtime, agent, agent_name, auto),
+        None => plan_image(slug, repo_root, vcs, cfg, runtime, agent, agent_name, auto,
+            container_name),
     }
 }
 
@@ -418,6 +440,7 @@ fn plan_image(
     agent: Option<container::KnownAgent>,
     agent_name: Option<&str>,
     auto: bool,
+    container_name: &str,
 ) -> anyhow::Result<ContainerPlan> {
     let image = config::resolve_image(agent_name, cfg)
         .ok_or(error::AmError::ContainerImageNotConfigured)?;
@@ -443,7 +466,7 @@ fn plan_image(
         &cfg.container.env,
         &agent_auth.env,
         &cfg.container.network,
-        &format!("am-{slug}"),
+        container_name,
         &container::DevcontainerRuntime::default(),
     );
     cmd.extend(agent_command(agent, auto));
@@ -471,6 +494,7 @@ fn plan_devcontainer(
     auto: bool,
     rebuild: bool,
     config_path: &std::path::Path,
+    container_name: &str,
 ) -> anyhow::Result<ContainerPlan> {
     let json = devcontainer::parse_config(config_path)?;
     devcontainer::check_supported(&json)?;
@@ -539,7 +563,7 @@ fn plan_devcontainer(
         &cfg.container.env,
         &agent_auth.env,
         &cfg.container.network,
-        &format!("am-{slug}"),
+        container_name,
         &trusted,
     );
     // Feature entrypoints and lifecycle hooks must run before the agent, and am overrides
@@ -558,6 +582,7 @@ fn plan_devcontainer(
         session: session::SessionContainer {
             runtime: runtime.kind.to_string(),
             image,
+            container_name: None,
             container_id: None,
             mode: session::ContainerMode::Devcontainer,
             config_path: Some(config_path.to_path_buf()),
@@ -762,39 +787,45 @@ fn cmd_attach(slug: &str) -> anyhow::Result<()> {
     }
     let sessions = session::load_sessions_for_repo(&repo_root)?;
 
-    let s = session::find_session(&sessions, slug)
-        .ok_or_else(|| error::AmError::SlugNotFound(slug.to_string()))?;
+    let mut s = session::find_session(&sessions, slug)
+        .ok_or_else(|| error::AmError::SlugNotFound(slug.to_string()))?
+        .clone();
 
     if !tmux::is_in_tmux() {
         return Err(error::AmError::NotInTmux.into());
     }
 
-    let window_name = format!("am-{slug}");
+    let window_name = &s.tmux.tmux_window;
+    let window_target = s.tmux.tmux_window_id.as_deref().unwrap_or(window_name);
 
     // Try to switch to an existing window; if it's not there, create it.
-    if tmux::select_window(&window_name).is_err() {
+    if tmux::select_window(window_target).is_err() {
         let project_config_path = repo_root.join(".am").join("config.toml");
         let cfg = config::load_with_global(
             config::global_config_path().as_deref(),
             Some(&project_config_path),
         )?;
-        tmux::create_window(&window_name, &s.vcs.worktree_path)
+        let window_id = tmux::create_window(window_name, &s.vcs.worktree_path)
             .map_err(|e| anyhow::anyhow!(
                 "{e}\nHint: a window named '{window_name}' may already exist — run 'am destroy {slug}' first"
             ))?;
-        let (shell_pane_idx, new_pane_percent) = match cfg.tmux.agent_pane {
-            config::PaneSide::Right => (0usize, cfg.tmux.split_percent),
-            config::PaneSide::Left => (1usize, 100 - cfg.tmux.split_percent),
+        let (agent_pane_idx, shell_pane_idx, new_pane_percent) = match cfg.tmux.agent_pane {
+            config::PaneSide::Right => (1usize, 0usize, cfg.tmux.split_percent),
+            config::PaneSide::Left => (0usize, 1usize, 100 - cfg.tmux.split_percent),
         };
         tmux::split_window(
-            &window_name,
+            &window_id,
             &s.vcs.worktree_path,
             &cfg.tmux.split,
             new_pane_percent,
             None,
         )?;
-        tmux::select_pane(&tmux::get_pane_id(&window_name, shell_pane_idx))?;
-        tmux::select_window(&window_name)?;
+        tmux::select_pane(&tmux::get_pane_id(&window_id, shell_pane_idx))?;
+        tmux::select_window(&window_id)?;
+        s.tmux.tmux_window_id = Some(window_id.clone());
+        s.tmux.agent_pane = tmux::get_pane_id(&window_id, agent_pane_idx);
+        s.tmux.shell_pane = tmux::get_pane_id(&window_id, shell_pane_idx);
+        session::update_session_global(s.clone())?;
         println!("Opened new window for session '{slug}'.");
         if s.container.is_some() {
             println!("  Note: the container was stopped when the window closed.");
@@ -823,7 +854,7 @@ fn cmd_run(slug: &str, agent: &str) -> anyhow::Result<()> {
     }
 
     tmux::send_keys(&s.tmux.agent_pane, agent)?;
-    tmux::select_window(&s.tmux.tmux_window)?;
+    tmux::select_window(s.tmux.tmux_window_id.as_deref().unwrap_or(&s.tmux.tmux_window))?;
     println!("Launched '{agent}' in session '{slug}'.");
     Ok(())
 }
@@ -866,8 +897,9 @@ fn cmd_destroy(slug: &str, force: bool, msgs: &messages::Messages) -> anyhow::Re
             _ => config::RuntimePreference::Podman,
         };
         if let Ok(rt) = container::detect_runtime(pref) {
-            let _ = container::stop_container(&rt, &format!("am-{slug}"));
-            let _ = container::remove_container(&rt, &format!("am-{slug}"));
+            let container_name = sc.container_name.as_deref().unwrap_or(&s.tmux.tmux_window);
+            let _ = container::stop_container(&rt, container_name);
+            let _ = container::remove_container(&rt, container_name);
         }
     }
 
@@ -880,11 +912,13 @@ fn cmd_destroy(slug: &str, force: bool, msgs: &messages::Messages) -> anyhow::Re
             }
             let _ = tmux::kill_pane(&s.tmux.agent_pane);
             if let Some(ref orig) = s.tmux.original_window_name {
-                let _ = tmux::rename_window(Some(&s.tmux.tmux_window), orig);
+                let target = s.tmux.tmux_window_id.as_deref().unwrap_or(&s.tmux.tmux_window);
+                let _ = tmux::rename_window(Some(target), orig);
             }
         } else {
             // Old-style session: the window was dedicated, kill it entirely.
-            let _ = tmux::kill_window(&s.tmux.tmux_window);
+            let target = s.tmux.tmux_window_id.as_deref().unwrap_or(&s.tmux.tmux_window);
+            let _ = tmux::kill_window(target);
         }
     }
 
@@ -956,30 +990,28 @@ fn cmd_session_rm(slug: &str, repo: Option<&std::path::Path>, force: bool) -> an
                     .iter()
                     .filter(|s| s.repo_root == root && s.slug == slug)
                     .collect();
-                if !for_this_repo.is_empty() {
-                    // Slug matches current repo — use it.
+                // Look across all repos for this slug.
+                let matching: Vec<_> = all
+                    .iter()
+                    .filter(|s| s.slug == slug)
+                    .collect();
+                if matching.is_empty() {
+                    return Err(error::AmError::SlugNotFound(slug.to_string()).into());
+                } else if matching.len() == 1 {
+                    matching[0].repo_root.clone()
+                } else if !for_this_repo.is_empty() && matching.len() == for_this_repo.len() {
+                    // All matches are in the current repo — no ambiguity.
                     root
                 } else {
-                    // Slug not in current repo; look across all repos.
-                    let matching: Vec<_> = all
+                    let repos: Vec<_> = matching
                         .iter()
-                        .filter(|s| s.slug == slug)
+                        .map(|s| format!("  {}", s.repo_root.display()))
                         .collect();
-                    if matching.is_empty() {
-                        return Err(error::AmError::SlugNotFound(slug.to_string()).into());
-                    } else if matching.len() == 1 {
-                        matching[0].repo_root.clone()
-                    } else {
-                        let repos: Vec<_> = matching
-                            .iter()
-                            .map(|s| format!("  {}", s.repo_root.display()))
-                            .collect();
-                        return Err(anyhow::anyhow!(
-                            "slug '{}' exists in multiple repos:\n{}\nUse --repo <path> to specify which one.",
-                            slug,
-                            repos.join("\n")
-                        ));
-                    }
+                    return Err(anyhow::anyhow!(
+                        "slug '{}' exists in multiple repos:\n{}\nUse --repo <path> to specify which one.",
+                        slug,
+                        repos.join("\n")
+                    ));
                 }
             }
             Err(_) => {
@@ -1036,17 +1068,19 @@ fn cmd_session_rm(slug: &str, repo: Option<&std::path::Path>, force: bool) -> an
             _ => config::RuntimePreference::Podman,
         };
         if let Ok(rt) = container::detect_runtime(pref) {
-            if let Err(e) = container::stop_container(&rt, &format!("am-{slug}")) {
+            let container_name = sc.container_name.as_deref().unwrap_or(&s.tmux.tmux_window);
+            if let Err(e) = container::stop_container(&rt, container_name) {
                 eprintln!("warning: container cleanup failed: {e}");
             }
-            if let Err(e) = container::remove_container(&rt, &format!("am-{slug}")) {
+            if let Err(e) = container::remove_container(&rt, container_name) {
                 eprintln!("warning: container cleanup failed: {e}");
             }
         }
     }
 
     // Best-effort tmux cleanup.
-    if let Err(e) = tmux::kill_window(&s.tmux.tmux_window) {
+    let window_target = s.tmux.tmux_window_id.as_deref().unwrap_or(&s.tmux.tmux_window);
+    if let Err(e) = tmux::kill_window(window_target) {
         eprintln!("warning: tmux cleanup failed: {e}");
     }
 
@@ -1245,5 +1279,38 @@ mod tests {
             agent_command(Some(KnownAgent::Claude), true),
             vec!["claude", "--dangerously-skip-permissions"]
         );
+    }
+
+    // ── container_name ───────────────────────────────────────────────────────
+
+    use super::container_name;
+    use std::path::Path;
+
+    #[test]
+    fn container_name_includes_a_hash() {
+        let name = container_name(Path::new("/repo-a"), "feat");
+        assert!(name.starts_with("am-feat-"), "expected hash suffix, got: {name}");
+        assert!(name.len() > "am-feat-".len(), "hash suffix should not be empty");
+    }
+
+    #[test]
+    fn container_name_is_deterministic() {
+        let a = container_name(Path::new("/repo-b"), "feat");
+        let b = container_name(Path::new("/repo-b"), "feat");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn container_name_differs_across_repos() {
+        let b = container_name(Path::new("/repo-b"), "feat");
+        let c = container_name(Path::new("/repo-c"), "feat");
+        assert_ne!(b, c);
+    }
+
+    #[test]
+    fn container_name_differs_across_slugs() {
+        let a = container_name(Path::new("/repo-a"), "feat");
+        let b = container_name(Path::new("/repo-a"), "bugfix");
+        assert_ne!(a, b);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 
 use anyhow::Context as _;
 use clap::Parser;
-use cli::{Cli, Commands};
+use cli::{Cli, Commands, SessionCommands};
 use command::shell_quote;
 
 fn main() {
@@ -40,12 +40,17 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             auto,
             rebuild,
         } => cmd_start(&slug, agent.as_deref(), no_container, auto, rebuild),
-        Commands::List => cmd_list(),
+        Commands::List { all } => cmd_list(all),
         Commands::Attach { slug } => cmd_attach(&slug),
         Commands::Run { slug, agent } => cmd_run(&slug, &agent),
         Commands::Destroy { slug, force } => cmd_destroy(&slug, force, &msgs),
         Commands::Doctor => cmd_doctor(None),
         Commands::GenerateConfig => cmd_generate_config(),
+        Commands::Session { command } => match command {
+            SessionCommands::Rm { slug, repo, force } => {
+                cmd_session_rm(&slug, repo.as_deref(), force)
+            }
+        },
     }
 }
 
@@ -65,39 +70,37 @@ fn cmd_init() -> anyhow::Result<()> {
         println!(".am/config.toml already exists, skipping");
     }
 
-    let sessions_path = am_dir.join("sessions.json");
-    if !sessions_path.exists() {
-        std::fs::write(&sessions_path, "{\"sessions\":[]}\n")?;
-        println!("Created .am/sessions.json");
-    }
-
-    let gitconfig_path = am_dir.join("gitconfig");
-    if !gitconfig_path.exists() {
-        let name = read_git_config("user.name").unwrap_or_default();
-        let email = read_git_config("user.email").unwrap_or_default();
-        let content = format!("[user]\n\tname = {name}\n\temail = {email}\n");
-        std::fs::write(&gitconfig_path, content)?;
-        println!("Created .am/gitconfig");
-    } else {
-        println!(".am/gitconfig already exists, skipping");
-    }
-
     let gitignore_path = repo_root.join(".gitignore");
-    let already_ignored = if gitignore_path.exists() {
-        let content = std::fs::read_to_string(&gitignore_path)?;
-        content
-            .lines()
-            .any(|l| l.trim() == ".am/" || l.trim() == ".am")
+    let gitignore_content = if gitignore_path.exists() {
+        std::fs::read_to_string(&gitignore_path)?
     } else {
-        false
+        String::new()
     };
-    if !already_ignored {
+
+    // Check for old-style broad .am/ entry and print advisory.
+    let has_old_am_entry = gitignore_content
+        .lines()
+        .any(|l| l.trim() == ".am/" || l.trim() == ".am");
+    if has_old_am_entry {
+        println!(
+            "Note: .am/ is in .gitignore; .am/config.toml is now committable — \
+             you may want to narrow this to .am/worktrees/"
+        );
+    }
+
+    // Check if .am/worktrees/ is already present.
+    let worktrees_already_ignored = gitignore_content
+        .lines()
+        .any(|l| l.trim() == ".am/worktrees/" || l.trim() == ".am/worktrees");
+    if worktrees_already_ignored {
+        println!(".am/worktrees/ already in .gitignore, skipping");
+    } else {
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(&gitignore_path)?;
-        file.write_all(b".am/\n")?;
-        println!("Added .am/ to .gitignore");
+        file.write_all(b".am/worktrees/\n")?;
+        println!("Added .am/worktrees/ to .gitignore");
     }
 
     println!("am initialized. Run 'am start <slug>' to create your first session.");
@@ -114,7 +117,14 @@ fn cmd_start(
     rebuild: bool,
 ) -> anyhow::Result<()> {
     let (repo_root, vcs) = find_repo_root()?;
-    let sessions = session::load_sessions(&repo_root)?;
+
+    // Migration: transparently move old per-repo sessions to the global store.
+    // Ignore migration errors — they are warnings, not blockers.
+    if let Err(e) = session::migrate_sessions(&repo_root) {
+        eprintln!("warning: session migration failed: {e}");
+    }
+
+    let sessions = session::load_sessions_for_repo(&repo_root)?;
 
     if session::find_session(&sessions, slug).is_some() {
         return Err(error::AmError::SlugAlreadyExists(slug.to_string()).into());
@@ -151,15 +161,15 @@ fn cmd_start(
         .map(container::KnownAgent::parse)
         .transpose()?;
 
-    // 4. Require am init when using containers
-    if cfg.container.enabled && !no_container {
-        let gitconfig_path = repo_root.join(".am").join("gitconfig");
-        if !gitconfig_path.exists() && cfg.container.gitconfig.is_none() {
-            return Err(anyhow::anyhow!(
-                ".am/gitconfig not found — run 'am init' first to create the project configuration"
-            ));
-        }
-    }
+    // 4. Generate gitconfig in the global state directory.
+    //    This replaces the old .am/gitconfig check — we generate it unconditionally.
+    let state_dir = config::global_state_dir()
+        .ok_or(error::AmError::GlobalStateDirNotFound)?;
+    std::fs::create_dir_all(&state_dir)?;
+    let name = read_git_config("user.name").unwrap_or_default();
+    let email = read_git_config("user.email").unwrap_or_default();
+    let gitconfig_path = state_dir.join("gitconfig");
+    std::fs::write(&gitconfig_path, format!("[user]\n\tname = {name}\n\temail = {email}\n"))?;
 
     // 5. Container runtime and host-side credentials. Everything checkable without a
     //    worktree is checked here; a devcontainer config only exists once the worktree
@@ -258,6 +268,7 @@ fn cmd_start(
         slug: slug.to_string(),
         created_at: chrono::Utc::now(),
         auto,
+        repo_root: repo_root.clone(),
         vcs: session::VcsMetadata {
             branch: format!("am/{slug}"),
             worktree_path: worktree_path.clone(),
@@ -280,7 +291,7 @@ fn cmd_start(
     // the user can run 'am destroy <slug>' to clean up.
     if let Some(ref cmd) = container_cmd {
         if !tmux::is_in_tmux() {
-            session::add_session(&repo_root, new_session)?;
+            session::add_session_global(new_session)?;
             guard.commit();
             println!("Started session '{slug}'");
             println!("  worktree:  {}", worktree_path.display());
@@ -312,7 +323,7 @@ fn cmd_start(
         .container
         .as_ref()
         .map(|c| (c.mode, c.image.clone()));
-    session::add_session(&repo_root, new_session)?;
+    session::add_session_global(new_session)?;
     guard.commit();
 
     println!("Started session '{slug}'");
@@ -594,9 +605,25 @@ fn injected_features(
 
 // ── am list ───────────────────────────────────────────────────────────────────
 
-fn cmd_list() -> anyhow::Result<()> {
-    let (repo_root, _) = find_repo_root()?;
-    let sessions = session::load_sessions(&repo_root)?;
+fn cmd_list(all: bool) -> anyhow::Result<()> {
+    if all {
+        cmd_list_all()
+    } else {
+        cmd_list_repo()
+    }
+}
+
+fn cmd_list_repo() -> anyhow::Result<()> {
+    let (repo_root, _) = find_repo_root().map_err(|e| {
+        anyhow::anyhow!("{e}\nRun 'am list --all' to see sessions from all repos.")
+    })?;
+
+    // Migration: transparently move old per-repo sessions to the global store.
+    if let Err(e) = session::migrate_sessions(&repo_root) {
+        eprintln!("warning: session migration failed: {e}");
+    }
+
+    let sessions = session::load_sessions_for_repo(&repo_root)?;
 
     if sessions.is_empty() {
         println!("No active sessions. Run 'am start <slug>' to begin.");
@@ -643,11 +670,94 @@ fn cmd_list() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn cmd_list_all() -> anyhow::Result<()> {
+    let home_dir = std::env::var_os("HOME").map(std::path::PathBuf::from);
+
+    let sessions = session::load_all_sessions()?;
+
+    if sessions.is_empty() {
+        println!("No sessions found across any repo.");
+        return Ok(());
+    }
+
+    // Sort: non-stale first (by repo_root, then created_at), stale last.
+    let mut sessions = sessions;
+    sessions.sort_by(|a, b| {
+        let a_stale = !a.repo_root.exists();
+        let b_stale = !b.repo_root.exists();
+        a_stale
+            .cmp(&b_stale)
+            .then_with(|| a.repo_root.cmp(&b.repo_root))
+            .then_with(|| a.created_at.cmp(&b.created_at))
+    });
+
+    let abbrev_home = |p: &std::path::Path| -> String {
+        if let Some(ref home) = home_dir {
+            if let Ok(rel) = p.strip_prefix(home) {
+                return format!("~/{}", rel.display());
+            }
+        }
+        p.display().to_string()
+    };
+
+    let slug_w = sessions
+        .iter()
+        .map(|s| s.slug.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let repo_w = sessions
+        .iter()
+        .map(|s| abbrev_home(&s.repo_root).len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let path_w = sessions
+        .iter()
+        .map(|s| s.vcs.worktree_path.display().to_string().len())
+        .max()
+        .unwrap_or(8)
+        .max(8);
+
+    println!(
+        "{:<repo_w$}  {:<slug_w$}  {:<9}  {:<4}  {:<path_w$}  {:<10}  {:<7}  CREATED",
+        "REPO", "SLUG", "CONTAINER", "AUTO", "WORKTREE", "WINDOW", "STATUS",
+    );
+    println!("{}", "-".repeat(repo_w + slug_w + 9 + 4 + path_w + 10 + 7 + 19 + 14));
+
+    for s in &sessions {
+        let container = s
+            .container
+            .as_ref()
+            .map(|c| c.runtime.as_str())
+            .unwrap_or("—");
+        let auto = if s.auto { "yes" } else { "—" };
+        let created = s.created_at.format("%Y-%m-%d %H:%M").to_string();
+        let status = if s.repo_root.exists() { "" } else { "stale" };
+        let repo = abbrev_home(&s.repo_root);
+        println!(
+            "{:<repo_w$}  {:<slug_w$}  {:<9}  {:<4}  {:<path_w$}  {:<10}  {:<7}  {}",
+            repo,
+            s.slug,
+            container,
+            auto,
+            s.vcs.worktree_path.display(),
+            s.tmux.tmux_window,
+            status,
+            created,
+        );
+    }
+    Ok(())
+}
+
 // ── am attach ────────────────────────────────────────────────────────────────
 
 fn cmd_attach(slug: &str) -> anyhow::Result<()> {
     let (repo_root, _) = find_repo_root()?;
-    let sessions = session::load_sessions(&repo_root)?;
+    if let Err(e) = session::migrate_sessions(&repo_root) {
+        eprintln!("warning: session migration failed: {e}");
+    }
+    let sessions = session::load_sessions_for_repo(&repo_root)?;
 
     let s = session::find_session(&sessions, slug)
         .ok_or_else(|| error::AmError::SlugNotFound(slug.to_string()))?;
@@ -697,7 +807,10 @@ fn cmd_attach(slug: &str) -> anyhow::Result<()> {
 
 fn cmd_run(slug: &str, agent: &str) -> anyhow::Result<()> {
     let (repo_root, _) = find_repo_root()?;
-    let sessions = session::load_sessions(&repo_root)?;
+    if let Err(e) = session::migrate_sessions(&repo_root) {
+        eprintln!("warning: session migration failed: {e}");
+    }
+    let sessions = session::load_sessions_for_repo(&repo_root)?;
 
     let s = session::find_session(&sessions, slug)
         .ok_or_else(|| error::AmError::SlugNotFound(slug.to_string()))?;
@@ -716,7 +829,10 @@ fn cmd_run(slug: &str, agent: &str) -> anyhow::Result<()> {
 
 fn cmd_destroy(slug: &str, force: bool, msgs: &messages::Messages) -> anyhow::Result<()> {
     let (repo_root, vcs) = find_repo_root()?;
-    let sessions = session::load_sessions(&repo_root)?;
+    if let Err(e) = session::migrate_sessions(&repo_root) {
+        eprintln!("warning: session migration failed: {e}");
+    }
+    let sessions = session::load_sessions_for_repo(&repo_root)?;
 
     let s = session::find_session(&sessions, slug)
         .ok_or_else(|| error::AmError::SlugNotFound(slug.to_string()))?;
@@ -788,7 +904,7 @@ fn cmd_destroy(slug: &str, force: bool, msgs: &messages::Messages) -> anyhow::Re
     }
 
     // Remove session record
-    session::remove_session(&repo_root, slug)?;
+    session::remove_session_global(&repo_root, slug)?;
 
     println!("Destroyed session '{slug}'.");
     Ok(())
@@ -810,6 +926,131 @@ fn cmd_doctor(agent_flag: Option<&str>) -> anyhow::Result<()> {
     if report.failures() > 0 {
         std::process::exit(1);
     }
+    Ok(())
+}
+
+// ── am session rm ─────────────────────────────────────────────────────────────
+
+fn cmd_session_rm(slug: &str, repo: Option<&std::path::Path>, force: bool) -> anyhow::Result<()> {
+    // Resolve repo_root.
+    let repo_root: std::path::PathBuf = if let Some(r) = repo {
+        // Use provided --repo path as-is (need not exist — could be stale).
+        if r.is_absolute() {
+            r.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(r)
+        }
+    } else {
+        // No --repo: try to find the repo root from CWD.
+        match find_repo_root() {
+            Ok((root, _)) => {
+                // We're inside a repo. Check if slug matches this repo.
+                if let Err(e) = session::migrate_sessions(&root) {
+                    eprintln!("warning: session migration failed: {e}");
+                }
+                let all = session::load_all_sessions()?;
+                let for_this_repo: Vec<_> = all
+                    .iter()
+                    .filter(|s| s.repo_root == root && s.slug == slug)
+                    .collect();
+                if !for_this_repo.is_empty() {
+                    // Slug matches current repo — use it.
+                    root
+                } else {
+                    // Slug not in current repo; look across all repos.
+                    let matching: Vec<_> = all
+                        .iter()
+                        .filter(|s| s.slug == slug)
+                        .collect();
+                    if matching.is_empty() {
+                        return Err(error::AmError::SlugNotFound(slug.to_string()).into());
+                    } else if matching.len() == 1 {
+                        matching[0].repo_root.clone()
+                    } else {
+                        let repos: Vec<_> = matching
+                            .iter()
+                            .map(|s| format!("  {}", s.repo_root.display()))
+                            .collect();
+                        return Err(anyhow::anyhow!(
+                            "slug '{}' exists in multiple repos:\n{}\nUse --repo <path> to specify which one.",
+                            slug,
+                            repos.join("\n")
+                        ));
+                    }
+                }
+            }
+            Err(_) => {
+                // Not inside a repo — look across all sessions for this slug.
+                let all = session::load_all_sessions()?;
+                let matching: Vec<_> = all.iter().filter(|s| s.slug == slug).collect();
+                if matching.is_empty() {
+                    return Err(error::AmError::SlugNotFound(slug.to_string()).into());
+                } else if matching.len() == 1 {
+                    matching[0].repo_root.clone()
+                } else {
+                    let repos: Vec<_> = matching
+                        .iter()
+                        .map(|s| format!("  {}", s.repo_root.display()))
+                        .collect();
+                    return Err(anyhow::anyhow!(
+                        "slug '{}' exists in multiple repos:\n{}\nUse --repo <path> to specify which one.",
+                        slug,
+                        repos.join("\n")
+                    ));
+                }
+            }
+        }
+    };
+
+    // Find the session in the global store.
+    let all = session::load_all_sessions()?;
+    let s = all
+        .iter()
+        .find(|s| s.repo_root == repo_root && s.slug == slug)
+        .ok_or_else(|| error::AmError::SlugNotFound(slug.to_string()))?
+        .clone();
+
+    // Confirmation prompt (unless --force).
+    if !force {
+        print!(
+            "Remove session '{}' from {}? [y/N] ",
+            slug,
+            repo_root.display()
+        );
+        std::io::stdout().flush()?;
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    // Best-effort container cleanup.
+    if let Some(ref sc) = s.container {
+        let pref = match sc.runtime.as_str() {
+            "docker" => config::RuntimePreference::Docker,
+            _ => config::RuntimePreference::Podman,
+        };
+        if let Ok(rt) = container::detect_runtime(pref) {
+            if let Err(e) = container::stop_container(&rt, &format!("am-{slug}")) {
+                eprintln!("warning: container cleanup failed: {e}");
+            }
+            if let Err(e) = container::remove_container(&rt, &format!("am-{slug}")) {
+                eprintln!("warning: container cleanup failed: {e}");
+            }
+        }
+    }
+
+    // Best-effort tmux cleanup.
+    if let Err(e) = tmux::kill_window(&s.tmux.tmux_window) {
+        eprintln!("warning: tmux cleanup failed: {e}");
+    }
+
+    // Remove the record from the global store.
+    session::remove_session_global(&repo_root, slug)?;
+
+    println!("Removed session '{slug}'.");
     Ok(())
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::config;
 use crate::error::AmError;
 
 /// Where a session's image came from. Recorded so `am list` can distinguish the two and
@@ -93,6 +94,10 @@ pub struct Session {
     pub created_at: DateTime<Utc>,
     #[serde(default)]
     pub auto: bool,
+    /// Absolute path of the repository this session belongs to.
+    /// Populated by migration when reading old per-repo session files.
+    #[serde(default)]
+    pub repo_root: PathBuf,
     /// VCS-related metadata (branch, worktree path).
     #[serde(flatten)]
     pub vcs: VcsMetadata,
@@ -111,20 +116,43 @@ fn sessions_path(repo_root: &Path) -> PathBuf {
     repo_root.join(".am").join("sessions.json")
 }
 
-pub fn load_sessions(repo_root: &Path) -> Result<Vec<Session>> {
-    let path = sessions_path(repo_root);
+pub fn find_session<'a>(sessions: &'a [Session], slug: &str) -> Option<&'a Session> {
+    sessions.iter().find(|s| s.slug == slug)
+}
+
+// ── Global session store ──────────────────────────────────────────────────────
+
+/// Resolve the global sessions file path.
+/// Returns `None` only if neither `XDG_STATE_HOME` nor `HOME` is set.
+pub fn global_sessions_path() -> Option<PathBuf> {
+    config::global_state_dir().map(|d| d.join("sessions.json"))
+}
+
+/// Load all sessions from the global store.
+/// Returns an empty `Vec` if the file does not exist.
+pub fn load_all_sessions() -> Result<Vec<Session>> {
+    let path = global_sessions_path().ok_or(AmError::GlobalStateDirNotFound)?;
     if !path.exists() {
         return Ok(Vec::new());
     }
     let text = std::fs::read_to_string(&path)
-        .with_context(|| format!("reading sessions file {}", path.display()))?;
+        .with_context(|| format!("reading global sessions file {}", path.display()))?;
     let file: SessionFile = serde_json::from_str(&text)
-        .with_context(|| format!("parsing sessions file {}", path.display()))?;
+        .with_context(|| format!("parsing global sessions file {}", path.display()))?;
     Ok(file.sessions)
 }
 
-pub fn save_sessions(repo_root: &Path, sessions: &[Session]) -> Result<()> {
-    let path = sessions_path(repo_root);
+/// Load sessions belonging to a specific repo (filters by `repo_root`).
+/// Returns an empty `Vec` if the global file does not exist yet.
+pub fn load_sessions_for_repo(repo_root: &Path) -> Result<Vec<Session>> {
+    Ok(load_all_sessions()?
+        .into_iter()
+        .filter(|s| s.repo_root == repo_root)
+        .collect())
+}
+
+fn save_global_sessions(sessions: &[Session]) -> Result<()> {
+    let path = global_sessions_path().ok_or(AmError::GlobalStateDirNotFound)?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -136,27 +164,99 @@ pub fn save_sessions(repo_root: &Path, sessions: &[Session]) -> Result<()> {
     Ok(())
 }
 
-pub fn find_session<'a>(sessions: &'a [Session], slug: &str) -> Option<&'a Session> {
-    sessions.iter().find(|s| s.slug == slug)
-}
-
-pub fn add_session(repo_root: &Path, session: Session) -> Result<()> {
-    let mut sessions = load_sessions(repo_root)?;
-    if find_session(&sessions, &session.slug).is_some() {
+/// Add a session to the global store.
+/// Errors with `SlugAlreadyExists` if `(repo_root, slug)` already exists.
+pub fn add_session_global(session: Session) -> Result<()> {
+    let mut sessions = load_all_sessions()?;
+    if sessions
+        .iter()
+        .any(|s| s.repo_root == session.repo_root && s.slug == session.slug)
+    {
         return Err(AmError::SlugAlreadyExists(session.slug.clone()).into());
     }
     sessions.push(session);
-    save_sessions(repo_root, &sessions)
+    save_global_sessions(&sessions)
 }
 
-pub fn remove_session(repo_root: &Path, slug: &str) -> Result<()> {
-    let mut sessions = load_sessions(repo_root)?;
+/// Remove a session from the global store by `(repo_root, slug)`.
+/// Errors with `SlugNotFound` if not found.
+pub fn remove_session_global(repo_root: &Path, slug: &str) -> Result<()> {
+    let mut sessions = load_all_sessions()?;
     let before = sessions.len();
-    sessions.retain(|s| s.slug != slug);
+    sessions.retain(|s| !(s.repo_root == repo_root && s.slug == slug));
     if sessions.len() == before {
         return Err(AmError::SlugNotFound(slug.to_string()).into());
     }
-    save_sessions(repo_root, &sessions)
+    save_global_sessions(&sessions)
+}
+
+/// Migrate sessions from an old per-repo file into the global store.
+///
+/// Reads `<repo_root>/.am/sessions.json`, sets `repo_root` on each record,
+/// merges into the global store (skipping duplicates), then deletes the old file.
+///
+/// Returns the number of records migrated (0 if none, or if the file did not exist).
+/// On parse error, prints a warning and returns 0 without deleting the file.
+/// Idempotent: re-running after the old file is deleted is a no-op.
+pub fn migrate_sessions(repo_root: &Path) -> Result<usize> {
+    let old_path = sessions_path(repo_root);
+    if !old_path.exists() {
+        return Ok(0);
+    }
+
+    let text = match std::fs::read_to_string(&old_path) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!(
+                "warning: could not read .am/sessions.json for migration: {e} — leaving file in place"
+            );
+            return Ok(0);
+        }
+    };
+
+    let old_file: SessionFile = match serde_json::from_str(&text) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!(
+                "warning: could not parse .am/sessions.json for migration: {e} — leaving file in place"
+            );
+            return Ok(0);
+        }
+    };
+
+    if old_file.sessions.is_empty() {
+        // Nothing to migrate; still delete the now-empty old file.
+        let _ = std::fs::remove_file(&old_path);
+        return Ok(0);
+    }
+
+    // Load the global store; on error, propagate so we don't delete the old file.
+    let mut global = load_all_sessions()?;
+
+    let mut migrated = 0usize;
+    for mut session in old_file.sessions {
+        session.repo_root = repo_root.to_path_buf();
+        // Skip if (repo_root, slug) already exists in the global store.
+        let already_exists = global
+            .iter()
+            .any(|s| s.repo_root == session.repo_root && s.slug == session.slug);
+        if !already_exists {
+            global.push(session);
+            migrated += 1;
+        }
+    }
+
+    // Write global store before deleting old file — leave old file intact on write failure.
+    save_global_sessions(&global)?;
+
+    // Delete the old file now that the global write succeeded.
+    let _ = std::fs::remove_file(&old_path);
+
+    if migrated > 0 {
+        eprintln!("Migrated {migrated} session(s) from .am/sessions.json to global store.");
+    }
+
+    Ok(migrated)
 }
 
 #[cfg(test)]
@@ -164,11 +264,36 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    // Mutex to serialise all tests that mutate process-global env vars.
+    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// RAII guard that saves the current value of env vars on construction and
+    /// restores them on drop.
+    struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+    impl EnvGuard {
+        fn save(keys: &[&'static str]) -> Self {
+            Self(keys.iter().map(|k| (*k, std::env::var_os(k))).collect())
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.0 {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
     fn make_session(slug: &str) -> Session {
         Session {
             slug: slug.to_string(),
             created_at: Utc::now(),
             auto: false,
+            repo_root: PathBuf::new(),
             vcs: VcsMetadata {
                 branch: format!("am/{slug}"),
                 worktree_path: PathBuf::from(format!(".am/worktrees/{slug}")),
@@ -184,25 +309,13 @@ mod tests {
         }
     }
 
-    #[test]
-    fn missing_sessions_file_returns_empty_list() {
-        let tmp = TempDir::new().unwrap();
-        let sessions = load_sessions(tmp.path()).unwrap();
-        assert!(sessions.is_empty());
+    fn make_session_for_repo(slug: &str, repo_root: &Path) -> Session {
+        let mut s = make_session(slug);
+        s.repo_root = repo_root.to_path_buf();
+        s
     }
 
-    #[test]
-    fn add_and_find_session() {
-        let tmp = TempDir::new().unwrap();
-        let session = make_session("feat");
-        add_session(tmp.path(), session.clone()).unwrap();
-
-        let sessions = load_sessions(tmp.path()).unwrap();
-        assert_eq!(sessions.len(), 1);
-        let found = find_session(&sessions, "feat").unwrap();
-        assert_eq!(found.slug, "feat");
-        assert_eq!(found.vcs.branch, "am/feat");
-    }
+    // ── find_session ────────────────────────────────────────────────────────────
 
     #[test]
     fn find_session_returns_none_for_missing_slug() {
@@ -211,44 +324,31 @@ mod tests {
     }
 
     #[test]
-    fn add_duplicate_slug_errors() {
-        let tmp = TempDir::new().unwrap();
-        add_session(tmp.path(), make_session("feat")).unwrap();
-        let err = add_session(tmp.path(), make_session("feat")).unwrap_err();
-        assert!(err.to_string().contains("feat"));
+    fn find_session_returns_match() {
+        let sessions = vec![make_session("feat"), make_session("bugfix")];
+        let found = find_session(&sessions, "feat").unwrap();
+        assert_eq!(found.slug, "feat");
+        assert_eq!(found.vcs.branch, "am/feat");
     }
 
-    #[test]
-    fn remove_session_success() {
-        let tmp = TempDir::new().unwrap();
-        add_session(tmp.path(), make_session("feat")).unwrap();
-        add_session(tmp.path(), make_session("bugfix")).unwrap();
-
-        remove_session(tmp.path(), "feat").unwrap();
-
-        let sessions = load_sessions(tmp.path()).unwrap();
-        assert_eq!(sessions.len(), 1);
-        assert_eq!(sessions[0].slug, "bugfix");
-    }
-
-    #[test]
-    fn remove_nonexistent_slug_errors() {
-        let tmp = TempDir::new().unwrap();
-        let err = remove_session(tmp.path(), "ghost").unwrap_err();
-        assert!(err.to_string().contains("ghost"));
-    }
+    // ── JSON roundtrip via global store ──────────────────────────────────────
 
     #[test]
     fn sessions_roundtrip_json() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
         let tmp = TempDir::new().unwrap();
-        let mut s = make_session("feat");
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+        let mut s = make_session_for_repo("feat", &repo);
         let mut container =
             SessionContainer::image_mode("podman".to_string(), "myimage:latest".to_string());
         container.container_id = Some("abc123".to_string());
         s.container = Some(container);
-        add_session(tmp.path(), s).unwrap();
+        add_session_global(s).unwrap();
 
-        let loaded = load_sessions(tmp.path()).unwrap();
+        let loaded = load_all_sessions().unwrap();
         let c = loaded[0].container.as_ref().unwrap();
         assert_eq!(c.runtime, "podman");
         assert_eq!(c.container_id.as_deref(), Some("abc123"));
@@ -257,8 +357,13 @@ mod tests {
 
     #[test]
     fn devcontainer_session_roundtrips_json() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
         let tmp = TempDir::new().unwrap();
-        let mut s = make_session("feat");
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+        let mut s = make_session_for_repo("feat", &repo);
         s.container = Some(SessionContainer {
             runtime: "podman".to_string(),
             image: "am-dc-abc123".to_string(),
@@ -269,9 +374,9 @@ mod tests {
             remote_user: Some("vscode".to_string()),
             lifecycle_done: vec!["postCreateCommand".to_string()],
         });
-        add_session(tmp.path(), s).unwrap();
+        add_session_global(s).unwrap();
 
-        let loaded = load_sessions(tmp.path()).unwrap();
+        let loaded = load_all_sessions().unwrap();
         let c = loaded[0].container.as_ref().unwrap();
         assert_eq!(c.mode, ContainerMode::Devcontainer);
         assert_eq!(c.config_hash.as_deref(), Some("abc123"));
@@ -280,13 +385,18 @@ mod tests {
     }
 
     #[test]
-    fn records_written_before_devcontainer_support_still_load() {
-        // Sessions on disk predate every field added for devcontainer mode; a user
-        // upgrading am must not have to destroy their running sessions.
+    fn legacy_records_without_repo_root_migrate_correctly() {
+        // Sessions on disk predate the repo_root field and devcontainer fields;
+        // migration must handle missing fields gracefully.
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
         let tmp = TempDir::new().unwrap();
-        std::fs::create_dir_all(tmp.path().join(".am")).unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(repo.join(".am")).unwrap();
         std::fs::write(
-            tmp.path().join(".am").join("sessions.json"),
+            repo.join(".am").join("sessions.json"),
             r#"{"sessions":[{
                 "slug":"legacy",
                 "created_at":"2026-01-01T00:00:00Z",
@@ -300,11 +410,306 @@ mod tests {
         )
         .unwrap();
 
-        let loaded = load_sessions(tmp.path()).unwrap();
+        let count = migrate_sessions(&repo).unwrap();
+        assert_eq!(count, 1);
 
+        let loaded = load_all_sessions().unwrap();
+        assert_eq!(loaded[0].repo_root, repo);
         let c = loaded[0].container.as_ref().unwrap();
         assert_eq!(c.mode, ContainerMode::Image);
         assert!(c.config_hash.is_none());
         assert!(c.lifecycle_done.is_empty());
+    }
+
+    // ── Global session path ───────────────────────────────────────────────────
+
+    #[test]
+    fn global_sessions_path_uses_xdg_state_home() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+        std::env::remove_var("HOME");
+
+        let path = global_sessions_path();
+        assert_eq!(path, Some(tmp.path().join("am").join("sessions.json")));
+    }
+
+    #[test]
+    fn global_sessions_path_falls_back_to_home() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::remove_var("XDG_STATE_HOME");
+        std::env::set_var("HOME", tmp.path());
+
+        let path = global_sessions_path();
+        assert_eq!(
+            path,
+            Some(
+                tmp.path()
+                    .join(".local")
+                    .join("state")
+                    .join("am")
+                    .join("sessions.json")
+            )
+        );
+    }
+
+    #[test]
+    fn global_sessions_path_returns_none_without_home() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        std::env::remove_var("XDG_STATE_HOME");
+        std::env::remove_var("HOME");
+
+        assert_eq!(global_sessions_path(), None);
+    }
+
+    // ── add_session_global ────────────────────────────────────────────────────
+
+    #[test]
+    fn add_session_global_enforces_repo_slug_uniqueness() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+        let s = make_session_for_repo("feat", &repo);
+        add_session_global(s.clone()).unwrap();
+
+        let err = add_session_global(s).unwrap_err();
+        assert!(err.to_string().contains("feat"));
+    }
+
+    #[test]
+    fn add_session_global_allows_same_slug_in_different_repos() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo_a = tmp.path().join("repo-a");
+        let repo_b = tmp.path().join("repo-b");
+
+        add_session_global(make_session_for_repo("feat", &repo_a)).unwrap();
+        add_session_global(make_session_for_repo("feat", &repo_b)).unwrap();
+
+        let all = load_all_sessions().unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    // ── load_sessions_for_repo ────────────────────────────────────────────────
+
+    #[test]
+    fn load_sessions_for_repo_filters_by_repo_root() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo_a = tmp.path().join("repo-a");
+        let repo_b = tmp.path().join("repo-b");
+
+        add_session_global(make_session_for_repo("feat", &repo_a)).unwrap();
+        add_session_global(make_session_for_repo("bugfix", &repo_b)).unwrap();
+        add_session_global(make_session_for_repo("other", &repo_a)).unwrap();
+
+        let for_a = load_sessions_for_repo(&repo_a).unwrap();
+        assert_eq!(for_a.len(), 2);
+        assert!(for_a.iter().all(|s| s.repo_root == repo_a));
+
+        let for_b = load_sessions_for_repo(&repo_b).unwrap();
+        assert_eq!(for_b.len(), 1);
+        assert_eq!(for_b[0].slug, "bugfix");
+    }
+
+    #[test]
+    fn load_sessions_for_repo_returns_empty_when_no_global_file() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("nonexistent-repo");
+        let sessions = load_sessions_for_repo(&repo).unwrap();
+        assert!(sessions.is_empty());
+    }
+
+    // ── remove_session_global ─────────────────────────────────────────────────
+
+    #[test]
+    fn remove_session_global_removes_correct_record() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+        add_session_global(make_session_for_repo("feat", &repo)).unwrap();
+        add_session_global(make_session_for_repo("bugfix", &repo)).unwrap();
+
+        remove_session_global(&repo, "feat").unwrap();
+
+        let remaining = load_all_sessions().unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].slug, "bugfix");
+    }
+
+    #[test]
+    fn remove_session_global_errors_when_not_found() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+        let err = remove_session_global(&repo, "ghost").unwrap_err();
+        assert!(err.to_string().contains("ghost"));
+    }
+
+    // ── migrate_sessions ──────────────────────────────────────────────────────
+
+    fn write_old_sessions_file(repo_root: &Path, sessions_json: &str) {
+        let am_dir = repo_root.join(".am");
+        std::fs::create_dir_all(&am_dir).unwrap();
+        std::fs::write(am_dir.join("sessions.json"), sessions_json).unwrap();
+    }
+
+    #[test]
+    fn migrate_sessions_moves_records_and_deletes_old_file() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+        write_old_sessions_file(
+            &repo,
+            r#"{"sessions":[{
+                "slug":"feat",
+                "created_at":"2026-01-01T00:00:00Z",
+                "branch":"am/feat",
+                "worktree_path":".am/worktrees/feat",
+                "tmux_window":"am-feat",
+                "agent_pane":"am-feat.1",
+                "shell_pane":"am-feat.0"
+            }]}"#,
+        );
+
+        let count = migrate_sessions(&repo).unwrap();
+        assert_eq!(count, 1);
+
+        // Old file should be deleted.
+        assert!(!repo.join(".am").join("sessions.json").exists());
+
+        // Record should be in the global store with repo_root set.
+        let all = load_all_sessions().unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].slug, "feat");
+        assert_eq!(all[0].repo_root, repo);
+    }
+
+    #[test]
+    fn migrate_sessions_is_idempotent() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+        write_old_sessions_file(
+            &repo,
+            r#"{"sessions":[{
+                "slug":"feat",
+                "created_at":"2026-01-01T00:00:00Z",
+                "branch":"am/feat",
+                "worktree_path":".am/worktrees/feat",
+                "tmux_window":"am-feat",
+                "agent_pane":"am-feat.1",
+                "shell_pane":"am-feat.0"
+            }]}"#,
+        );
+
+        migrate_sessions(&repo).unwrap();
+        // Second call — old file is gone, should return 0 without error.
+        let count = migrate_sessions(&repo).unwrap();
+        assert_eq!(count, 0);
+
+        let all = load_all_sessions().unwrap();
+        assert_eq!(all.len(), 1, "no duplicates after idempotent migration");
+    }
+
+    #[test]
+    fn migrate_sessions_skips_duplicates() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+
+        // Pre-seed the global store with the same session.
+        add_session_global(make_session_for_repo("feat", &repo)).unwrap();
+
+        // Write old file with same slug.
+        write_old_sessions_file(
+            &repo,
+            r#"{"sessions":[{
+                "slug":"feat",
+                "created_at":"2026-01-01T00:00:00Z",
+                "branch":"am/feat",
+                "worktree_path":".am/worktrees/feat",
+                "tmux_window":"am-feat",
+                "agent_pane":"am-feat.1",
+                "shell_pane":"am-feat.0"
+            }]}"#,
+        );
+
+        let count = migrate_sessions(&repo).unwrap();
+        assert_eq!(count, 0, "duplicate should be skipped");
+
+        // Global store must not have duplicates.
+        let all = load_all_sessions().unwrap();
+        assert_eq!(all.len(), 1);
+        // Old file should be deleted even though 0 records were migrated
+        // (all were duplicates).
+        assert!(!repo.join(".am").join("sessions.json").exists());
+    }
+
+    #[test]
+    fn migrate_sessions_handles_malformed_old_file() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+        write_old_sessions_file(&repo, "this is not json {{{");
+
+        // Should return 0 and leave the file in place.
+        let count = migrate_sessions(&repo).unwrap();
+        assert_eq!(count, 0);
+        assert!(
+            repo.join(".am").join("sessions.json").exists(),
+            "malformed file should be left in place"
+        );
+    }
+
+    #[test]
+    fn migrate_sessions_handles_zero_records_deletes_file() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+        write_old_sessions_file(&repo, r#"{"sessions":[]}"#);
+
+        let count = migrate_sessions(&repo).unwrap();
+        assert_eq!(count, 0);
+        // Empty old file should be deleted silently.
+        assert!(!repo.join(".am").join("sessions.json").exists());
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -32,6 +32,10 @@ impl std::fmt::Display for ContainerMode {
 pub struct SessionContainer {
     pub runtime: String,
     pub image: String,
+    /// Runtime name used to address this container. Unlike a tmux title, this
+    /// is globally unique across repositories.
+    #[serde(default)]
+    pub container_name: Option<String>,
     pub container_id: Option<String>,
     /// Defaults to `Image` so records written before devcontainer support still load.
     #[serde(default)]
@@ -56,6 +60,7 @@ impl SessionContainer {
         Self {
             runtime,
             image,
+            container_name: None,
             container_id: None,
             mode: ContainerMode::Image,
             config_path: None,
@@ -76,7 +81,11 @@ pub struct VcsMetadata {
 /// Tmux-specific metadata for a session (window and pane names, original state).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TmuxMetadata {
+    /// Human-facing tmux window title. Titles are allowed to collide.
     pub tmux_window: String,
+    /// Stable tmux target (for example `@42`) used for programmatic actions.
+    #[serde(default)]
+    pub tmux_window_id: Option<String>,
     pub agent_pane: String,
     pub shell_pane: String,
     /// The window name before `am start` renamed it (new-style sessions only).
@@ -210,6 +219,18 @@ pub fn remove_session_global(repo_root: &Path, slug: &str) -> Result<()> {
     save_global_sessions(&sessions)
 }
 
+/// Replace an existing session after mutable runtime metadata changes.
+pub fn update_session_global(session: Session) -> Result<()> {
+    let _lock = lock_global_sessions()?;
+    let mut sessions = load_all_sessions()?;
+    let existing = sessions
+        .iter_mut()
+        .find(|s| s.repo_root == session.repo_root && s.slug == session.slug)
+        .ok_or_else(|| AmError::SlugNotFound(session.slug.clone()))?;
+    *existing = session;
+    save_global_sessions(&sessions)
+}
+
 /// Migrate sessions from an old per-repo file into the global store.
 ///
 /// Reads `<repo_root>/.am/sessions.json`, sets `repo_root` on each record,
@@ -321,6 +342,7 @@ mod tests {
             },
             tmux: TmuxMetadata {
                 tmux_window: format!("am-{slug}"),
+                tmux_window_id: None,
                 agent_pane: format!("am-{slug}.1"),
                 shell_pane: format!("am-{slug}.0"),
                 original_window_name: None,
@@ -388,6 +410,7 @@ mod tests {
         s.container = Some(SessionContainer {
             runtime: "podman".to_string(),
             image: "am-dc-abc123".to_string(),
+            container_name: Some("am-feat-deadbe".to_string()),
             container_id: None,
             mode: ContainerMode::Devcontainer,
             config_path: Some(PathBuf::from(".devcontainer/devcontainer.json")),

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,9 @@
+use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
 use crate::config;
@@ -128,6 +130,22 @@ pub fn global_sessions_path() -> Option<PathBuf> {
     config::global_state_dir().map(|d| d.join("sessions.json"))
 }
 
+/// Acquire an exclusive interprocess lock for the global sessions file.
+/// The returned `File` handle acts as the lock guard — dropping it releases the lock.
+fn lock_global_sessions() -> Result<File> {
+    let path = global_sessions_path().ok_or(AmError::GlobalStateDirNotFound)?;
+    let lock_path = path.with_extension("lock");
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let lock_file = File::create(&lock_path)
+        .with_context(|| format!("creating lock file {}", lock_path.display()))?;
+    lock_file
+        .lock_exclusive()
+        .with_context(|| format!("locking {}", lock_path.display()))?;
+    Ok(lock_file)
+}
+
 /// Load all sessions from the global store.
 /// Returns an empty `Vec` if the file does not exist.
 pub fn load_all_sessions() -> Result<Vec<Session>> {
@@ -167,6 +185,7 @@ fn save_global_sessions(sessions: &[Session]) -> Result<()> {
 /// Add a session to the global store.
 /// Errors with `SlugAlreadyExists` if `(repo_root, slug)` already exists.
 pub fn add_session_global(session: Session) -> Result<()> {
+    let _lock = lock_global_sessions()?;
     let mut sessions = load_all_sessions()?;
     if sessions
         .iter()
@@ -181,6 +200,7 @@ pub fn add_session_global(session: Session) -> Result<()> {
 /// Remove a session from the global store by `(repo_root, slug)`.
 /// Errors with `SlugNotFound` if not found.
 pub fn remove_session_global(repo_root: &Path, slug: &str) -> Result<()> {
+    let _lock = lock_global_sessions()?;
     let mut sessions = load_all_sessions()?;
     let before = sessions.len();
     sessions.retain(|s| !(s.repo_root == repo_root && s.slug == slug));
@@ -230,7 +250,8 @@ pub fn migrate_sessions(repo_root: &Path) -> Result<usize> {
         return Ok(0);
     }
 
-    // Load the global store; on error, propagate so we don't delete the old file.
+    // Lock and load the global store; on error, propagate so we don't delete the old file.
+    let _lock = lock_global_sessions()?;
     let mut global = load_all_sessions()?;
 
     let mut migrated = 0usize;

--- a/src/session.rs
+++ b/src/session.rs
@@ -187,7 +187,15 @@ fn save_global_sessions(sessions: &[Session]) -> Result<()> {
         sessions: sessions.to_vec(),
     };
     let text = serde_json::to_string_pretty(&file)?;
-    std::fs::write(&path, text)?;
+
+    // Write to a temporary file in the same directory, then rename into place.
+    // rename() is atomic on the same filesystem, so readers never see a
+    // partially-written sessions.json.
+    let tmp_path = path.with_extension("tmp");
+    std::fs::write(&tmp_path, text)
+        .with_context(|| format!("writing temporary sessions file {}", tmp_path.display()))?;
+    std::fs::rename(&tmp_path, &path)
+        .with_context(|| format!("renaming {} to {}", tmp_path.display(), path.display()))?;
     Ok(())
 }
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -45,25 +45,38 @@ fn run_tmux(bin: &Path, args: &[&str]) -> Result<()> {
     command::run_command(&bin.to_string_lossy(), args, AmError::TmuxError)
 }
 
+fn run_tmux_output(bin: &Path, args: &[&str]) -> Result<String> {
+    let mut cmd = std::process::Command::new(bin);
+    cmd.args(args);
+    command::run_built_command_output(cmd, AmError::TmuxError)
+}
+
 /// Returns `true` if the `$TMUX` environment variable is set (i.e. we are
 /// running inside a tmux session).
 pub fn is_in_tmux() -> bool {
     std::env::var("TMUX").is_ok()
 }
 
-/// `tmux new-window -n <window_name> -c <working_dir>`
-pub fn create_window(window_name: &str, working_dir: &Path) -> Result<()> {
+/// Create a window with a human-facing title and return its stable tmux ID.
+pub fn create_window(window_name: &str, working_dir: &Path) -> Result<String> {
     let bin = tmux_bin()?;
-    run_tmux(
+    let id = run_tmux_output(
         &bin,
         &[
             "new-window",
+            "-P",
+            "-F",
+            "#{window_id}",
             "-n",
             window_name,
             "-c",
             &working_dir.to_string_lossy(),
         ],
-    )
+    )?;
+    if id.is_empty() {
+        return Err(AmError::TmuxError("tmux did not return a window ID".to_string()).into());
+    }
+    Ok(id)
 }
 
 /// Split an existing window.
@@ -148,9 +161,9 @@ pub fn rename_window(target: Option<&str>, new_name: &str) -> Result<()> {
     }
 }
 
-/// Returns the pane target string `"<window_name>.<index>"`.
-pub fn get_pane_id(window_name: &str, index: usize) -> String {
-    format!("{window_name}.{index}")
+/// Returns the pane target string `"<window_target>.<index>"`.
+pub fn get_pane_id(window_target: &str, index: usize) -> String {
+    format!("{window_target}.{index}")
 }
 
 #[cfg(test)]
@@ -166,7 +179,7 @@ mod tests {
     /// Write a mock tmux script that appends its args to `$MOCK_TMUX_LOG`.
     fn make_mock_tmux(dir: &Path) -> std::path::PathBuf {
         let script = dir.join("mock_tmux");
-        std::fs::write(&script, "#!/bin/sh\necho \"$*\" >> \"$MOCK_TMUX_LOG\"\n").unwrap();
+        std::fs::write(&script, "#!/bin/sh\necho \"$*\" >> \"$MOCK_TMUX_LOG\"\nif [ \"$1\" = \"new-window\" ]; then echo '@1'; fi\n").unwrap();
         let mut perms = std::fs::metadata(&script).unwrap().permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(&script, perms).unwrap();
@@ -237,7 +250,7 @@ mod tests {
     #[test]
     fn create_window_sends_correct_command() {
         let mock = MockTmux::new();
-        create_window("am-feat", Path::new("/tmp/worktree")).unwrap();
+        assert_eq!(create_window("am-feat", Path::new("/tmp/worktree")).unwrap(), "@1");
         let out = mock.captured();
         assert!(
             out.contains("new-window"),

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -18,6 +18,8 @@ const AM_BIN: &str = env!("CARGO_BIN_EXE_am");
 pub struct AmWorld {
     /// Isolated temporary directory — serves as the project root.
     project_dir: TempDir,
+    /// Isolated temporary directory for global state (XDG_STATE_HOME).
+    state_dir: TempDir,
     /// Output from the most recent `am` invocation.
     last_output: Option<Output>,
     /// When Some, TMUX is mocked using this binary (+ log file).
@@ -42,6 +44,7 @@ impl Default for AmWorld {
     fn default() -> Self {
         Self {
             project_dir: TempDir::new().expect("create temp dir"),
+            state_dir: TempDir::new().expect("create state dir"),
             last_output: None,
             mock_tmux_bin: None,
             mock_tmux_log: None,
@@ -59,6 +62,11 @@ impl Default for AmWorld {
 impl AmWorld {
     fn project_path(&self) -> &Path {
         self.project_dir.path()
+    }
+
+    /// Path to the global sessions file: $state_dir/am/sessions.json
+    fn global_sessions_path(&self) -> PathBuf {
+        self.state_dir.path().join("am").join("sessions.json")
     }
 
     /// Install a mock tmux binary that logs every invocation to a file.
@@ -236,7 +244,9 @@ impl AmWorld {
     fn run_am(&mut self, args: &[&str]) {
         let dir = self.project_path().to_path_buf();
         let mut cmd = Command::new(AM_BIN);
-        cmd.args(args).current_dir(&dir);
+        cmd.args(args)
+            .current_dir(&dir)
+            .env("XDG_STATE_HOME", self.state_dir.path());
 
         // Container setup: use mock podman when available; disable otherwise.
         if let Some(ref podman_bin) = self.mock_podman_bin.clone() {
@@ -297,6 +307,7 @@ impl AmWorld {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .env("XDG_STATE_HOME", self.state_dir.path())
             .env("AM_CONTAINER_ENABLED", "false");
 
         if let Some(ref tmux_bin) = self.mock_tmux_bin.clone() {
@@ -541,7 +552,7 @@ async fn then_worktree_gone(world: &mut AmWorld, rel_path: String) {
 
 #[then(expr = "the session file contains {string}")]
 async fn then_session_contains(world: &mut AmWorld, slug: String) {
-    let sessions_path = world.project_path().join(".am").join("sessions.json");
+    let sessions_path = world.global_sessions_path();
     let content = fs::read_to_string(&sessions_path)
         .unwrap_or_else(|_| panic!("sessions.json not found at {sessions_path:?}"));
     assert!(
@@ -552,7 +563,7 @@ async fn then_session_contains(world: &mut AmWorld, slug: String) {
 
 #[then(expr = "the session file does not contain {string}")]
 async fn then_session_not_contain(world: &mut AmWorld, slug: String) {
-    let sessions_path = world.project_path().join(".am").join("sessions.json");
+    let sessions_path = world.global_sessions_path();
     if !sessions_path.exists() {
         return; // no file → no session → assertion trivially satisfied
     }

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -79,6 +79,9 @@ impl AmWorld {
              if [ -n \"$MOCK_TMUX_LOG\" ]; then\n\
                  echo \"$@\" >> \"$MOCK_TMUX_LOG\"\n\
              fi\n\
+             if [ \"$1\" = \"new-window\" ]; then\n\
+                 echo \"@1\"\n\
+             fi\n\
              exit 0\n",
         )
         .expect("write mock_tmux");
@@ -107,6 +110,9 @@ impl AmWorld {
                 "#!/bin/sh\n\
                  if [ -n \"$MOCK_TMUX_LOG\" ]; then\n\
                      echo \"$@\" >> \"$MOCK_TMUX_LOG\"\n\
+                 fi\n\
+                 if [ \"$1\" = \"new-window\" ]; then\n\
+                     echo \"@1\"\n\
                  fi\n\
                  if [ \"$1\" = \"select-window\" ] && [ ! -f \"{flag_str}\" ]; then\n\
                      touch \"{flag_str}\"\n\
@@ -468,6 +474,19 @@ async fn when_run(world: &mut AmWorld, cmd: String) {
     world.run_am(args);
 }
 
+#[given(expr = "the file {string} contains {string} without a trailing newline")]
+async fn given_file_without_trailing_newline(
+    world: &mut AmWorld,
+    rel_path: String,
+    content: String,
+) {
+    let path = world.project_path().join(&rel_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&path, &content).unwrap();
+}
+
 #[given(expr = "I have set env {string} to {string}")]
 async fn given_env_var(world: &mut AmWorld, key: String, value: String) {
     world.extra_env.push((key, value));
@@ -593,6 +612,16 @@ async fn then_file_contains(world: &mut AmWorld, rel_path: String, text: String)
     assert!(
         content.contains(&text),
         "expected {path:?} to contain {text:?}\ngot:\n{content}",
+    );
+}
+
+#[then(expr = "the file {string} does not contain {string}")]
+async fn then_file_does_not_contain(world: &mut AmWorld, rel_path: String, text: String) {
+    let path = world.project_path().join(&rel_path);
+    let content = fs::read_to_string(&path).unwrap_or_else(|_| panic!("could not read {path:?}"));
+    assert!(
+        !content.contains(&text),
+        "expected {path:?} to NOT contain {text:?}\ngot:\n{content}",
     );
 }
 

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -697,6 +697,6 @@ async fn main() {
     // block tokio threads, so parallel execution causes deadlocks.
     AmWorld::cucumber()
         .max_concurrent_scenarios(1)
-        .run("tests/features")
+        .run_and_exit("tests/features")
         .await;
 }

--- a/tests/features/init.feature
+++ b/tests/features/init.feature
@@ -5,8 +5,7 @@ Feature: am init — initialize am in a repo
     When I run "am init"
     Then the command succeeds
     And the file ".am/config.toml" exists
-    And the file ".am/sessions.json" exists
-    And the file ".gitignore" contains ".am/"
+    And the file ".gitignore" contains ".am/worktrees/"
 
   Scenario: init is idempotent when run twice
     Given a git repository

--- a/tests/features/init.feature
+++ b/tests/features/init.feature
@@ -7,6 +7,14 @@ Feature: am init — initialize am in a repo
     And the file ".am/config.toml" exists
     And the file ".gitignore" contains ".am/worktrees/"
 
+  Scenario: init appends correctly when .gitignore lacks a trailing newline
+    Given a git repository
+    And the file ".gitignore" contains "target/" without a trailing newline
+    When I run "am init"
+    Then the command succeeds
+    And the file ".gitignore" contains ".am/worktrees/"
+    And the file ".gitignore" does not contain "target/.am/worktrees/"
+
   Scenario: init is idempotent when run twice
     Given a git repository
     And am init has been run


### PR DESCRIPTION
## Summary

- Move session registry from per-repo `.am/sessions.json` to `$XDG_STATE_HOME/am/sessions.json`, enabling cross-repo session management
- Add `am list --all` to show sessions across all repos with stale detection (repo path no longer exists)
- Add `am session rm` to clean up orphaned session records with best-effort container/tmux cleanup
- Generate gitconfig transiently at `$XDG_STATE_HOME/am/gitconfig` during `am start` instead of persisting in `.am/`
- Narrow `.gitignore` from `.am/` to `.am/worktrees/`, making `.am/config.toml` committable for team-shared config
- Remove dead `vcs` config setting (VCS is always auto-detected by `find_repo_root()`)
- Transparent migration: old `.am/sessions.json` files are automatically migrated to the global store

## Test plan

- [x] 277 unit tests pass (including 14 new tests for global session functions and migration)
- [x] 53 cucumber integration scenarios pass (updated harness to use `XDG_STATE_HOME`)
- [x] clippy clean
- [x] Manual test: `am init` creates only `.am/config.toml` and `.am/worktrees/` in `.gitignore`
- [x] Manual test: `am start` writes session to `$XDG_STATE_HOME/am/sessions.json`
- [x] Manual test: `am list --all` shows sessions from multiple repos
- [x] Manual test: `am session rm` removes stale records
- [ ] Manual test: migration from old `.am/sessions.json` works transparently

🤖 Generated with [Claude Code](https://claude.com/claude-code)