### PR TITLE
fix(tmux): run the agent command in the pane tmux creates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -231,14 +231,8 @@ fn cmd_start(
     if let Some(container) = &mut session_container {
         container.container_name = Some(container_name.clone());
     }
-    // Pane assignment: split-window creates a new pane at index 1.
-    // PaneSide::Right: agent in new pane (1), shell in original (0).
-    // PaneSide::Left:  agent in original pane (0), shell in new pane (1).
-    // The -p percent controls the size of the new pane.
-    let (agent_pane_idx, shell_pane_idx, new_pane_percent) = match cfg.tmux.agent_pane {
-        config::PaneSide::Right => (1usize, 0usize, cfg.tmux.split_percent),
-        config::PaneSide::Left => (0usize, 1usize, 100 - cfg.tmux.split_percent),
-    };
+    // The -p percent always describes the new pane, which is always the agent's.
+    let (agent_pane_idx, shell_pane_idx, split_before) = pane_layout(&cfg.tmux.agent_pane);
 
     let tmux_window_id = if tmux::is_in_tmux() {
         // Create a dedicated window for the session instead of commandeering the
@@ -254,24 +248,23 @@ fn cmd_start(
                 .collect::<Vec<_>>()
                 .join(" ")
         });
-        let split_shell_cmd =
-            split_window_shell_cmd(container_shell_cmd.as_deref(), agent_pane_idx);
         tmux::split_window(
             &window_id,
             &worktree_path,
             &cfg.tmux.split,
-            new_pane_percent,
-            split_shell_cmd,
+            cfg.tmux.split_percent,
+            split_before,
+            container_shell_cmd.as_deref(),
         )
         .with_context(|| {
             format!("tmux split failed — run 'am destroy --force {slug}' to clean up")
         })?;
-        if let Some(ref cmd) = container_shell_cmd {
-            if split_shell_cmd.is_none() {
-                tmux::send_keys(&tmux::get_pane_id(&window_id, agent_pane_idx), cmd)?;
+        // A container command was exec'd by the split above. A host-side agent is short
+        // enough to type, and typing it leaves a shell behind when the agent exits.
+        if container_shell_cmd.is_none() {
+            if let Some(ref agent) = effective_agent {
+                tmux::send_keys(&tmux::get_pane_id(&window_id, agent_pane_idx), agent)?;
             }
-        } else if let Some(ref agent) = effective_agent {
-            tmux::send_keys(&tmux::get_pane_id(&window_id, agent_pane_idx), agent)?;
         }
         // Both panes already open in the worktree (via `new-window -c`), so no cd
         // is needed. Keep focus on the shell pane.
@@ -809,15 +802,13 @@ fn cmd_attach(slug: &str) -> anyhow::Result<()> {
             .map_err(|e| anyhow::anyhow!(
                 "{e}\nHint: a window named '{window_name}' may already exist — run 'am destroy {slug}' first"
             ))?;
-        let (agent_pane_idx, shell_pane_idx, new_pane_percent) = match cfg.tmux.agent_pane {
-            config::PaneSide::Right => (1usize, 0usize, cfg.tmux.split_percent),
-            config::PaneSide::Left => (0usize, 1usize, 100 - cfg.tmux.split_percent),
-        };
+        let (agent_pane_idx, shell_pane_idx, split_before) = pane_layout(&cfg.tmux.agent_pane);
         tmux::split_window(
             &window_id,
             &s.vcs.worktree_path,
             &cfg.tmux.split,
-            new_pane_percent,
+            cfg.tmux.split_percent,
+            split_before,
             None,
         )?;
         tmux::select_pane(&tmux::get_pane_id(&window_id, shell_pane_idx))?;
@@ -1107,17 +1098,20 @@ fn cd_cmd(path: &std::path::Path) -> String {
     format!("cd '{escaped}'")
 }
 
-
-/// `tmux split-window [shell-command]` runs the command in the newly created pane.
-/// Only attach the container command there when the agent pane is that new pane.
-fn split_window_shell_cmd(
-    container_shell_cmd: Option<&str>,
-    agent_pane_idx: usize,
-) -> Option<&str> {
-    if agent_pane_idx == 1 {
-        container_shell_cmd
-    } else {
-        None
+/// Map the configured agent side onto `(agent_pane_idx, shell_pane_idx, split_before)`.
+///
+/// The agent is *always* the pane `split-window` creates, so tmux can exec the container
+/// command in it directly. The alternative — leaving the agent in the window's original
+/// pane and typing the command in with send-keys — makes an interactive shell redraw a
+/// several-hundred-character line, which renders it twice and drops the whole `podman run`
+/// invocation into the user's shell history.
+///
+/// `-b` inserts the new pane before the existing one, which puts it left (horizontal split)
+/// or above (vertical) *and* makes it pane index 0.
+fn pane_layout(agent_pane: &config::PaneSide) -> (usize, usize, bool) {
+    match agent_pane {
+        config::PaneSide::Right => (1, 0, false),
+        config::PaneSide::Left => (0, 1, true),
     }
 }
 
@@ -1155,20 +1149,19 @@ fn find_repo_root() -> anyhow::Result<(PathBuf, config::Vcs)> {
 
 #[cfg(test)]
 mod tests {
-    use super::split_window_shell_cmd;
+    use super::pane_layout;
     use crate::command::shell_quote;
+    use crate::config::PaneSide;
 
     #[test]
-    fn split_window_shell_cmd_used_when_agent_is_new_pane() {
-        assert_eq!(
-            split_window_shell_cmd(Some("podman run image"), 1),
-            Some("podman run image")
-        );
+    fn pane_layout_puts_agent_in_the_new_pane_on_the_right() {
+        assert_eq!(pane_layout(&PaneSide::Right), (1, 0, false));
     }
 
     #[test]
-    fn split_window_shell_cmd_not_used_when_agent_is_original_pane() {
-        assert_eq!(split_window_shell_cmd(Some("podman run image"), 0), None);
+    fn pane_layout_puts_agent_in_the_new_pane_on_the_left() {
+        // -b, so the new pane is inserted first and becomes index 0.
+        assert_eq!(pane_layout(&PaneSide::Left), (0, 1, true));
     }
 
     #[test]

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -80,13 +80,14 @@ pub fn create_window(window_name: &str, working_dir: &Path) -> Result<String> {
 }
 
 /// Split an existing window.
-/// Horizontal: `tmux split-window -h -p <new_pane_percent> -c <working_dir> -t <window_name> [shell_cmd]`
-/// Vertical:   `tmux split-window -v -p <new_pane_percent> -c <working_dir> -t <window_name> [shell_cmd]`
+/// Horizontal: `tmux split-window -h [-b] -p <new_pane_percent> -c <working_dir> -t <window_name> [shell_cmd]`
+/// Vertical:   `tmux split-window -v [-b] -p <new_pane_percent> -c <working_dir> -t <window_name> [shell_cmd]`
 ///
 /// `new_pane_percent` is the percentage of the window given to the **new** pane (1–99).
-/// The caller is responsible for mapping the logical agent/shell pane assignment to the
-/// correct percentage (e.g. if the agent is in the new pane, pass `split_percent` directly;
-/// if the agent is in the original pane, pass `100 - split_percent`).
+///
+/// `before` adds `-b`, placing the new pane left of (horizontal) or above (vertical) the
+/// existing one, which also makes it pane index 0. This is what lets a caller put the new
+/// pane on either side without giving up the ability to run a command in it.
 ///
 /// `shell_cmd` — when `Some`, tmux runs this command (via `$SHELL -c`) in the new pane
 /// instead of an interactive shell.
@@ -95,6 +96,7 @@ pub fn split_window(
     working_dir: &Path,
     direction: &SplitDirection,
     new_pane_percent: u8,
+    before: bool,
     shell_cmd: Option<&str>,
 ) -> Result<()> {
     let bin = tmux_bin()?;
@@ -104,16 +106,11 @@ pub fn split_window(
     };
     let percent = new_pane_percent.to_string();
     let wd = working_dir.to_string_lossy();
-    let mut args = vec![
-        "split-window",
-        flag,
-        "-p",
-        &percent,
-        "-c",
-        &wd,
-        "-t",
-        window_name,
-    ];
+    let mut args = vec!["split-window", flag];
+    if before {
+        args.push("-b");
+    }
+    args.extend_from_slice(&["-p", &percent, "-c", &wd, "-t", window_name]);
     if let Some(cmd) = shell_cmd {
         args.push(cmd);
     }
@@ -269,6 +266,7 @@ mod tests {
             Path::new("/tmp/worktree"),
             &SplitDirection::Horizontal,
             50,
+            false,
             None,
         )
         .unwrap();
@@ -286,6 +284,7 @@ mod tests {
             Path::new("/tmp/worktree"),
             &SplitDirection::Vertical,
             50,
+            false,
             None,
         )
         .unwrap();
@@ -302,12 +301,49 @@ mod tests {
             Path::new("/tmp/worktree"),
             &SplitDirection::Horizontal,
             30,
+            false,
             None,
         )
         .unwrap();
         let out = mock.captured();
         assert!(out.contains("-p"), "expected -p flag, got: {out}");
         assert!(out.contains("30"), "expected percent value 30, got: {out}");
+    }
+
+    #[test]
+    fn split_window_before_passes_b_flag() {
+        let mock = MockTmux::new();
+        split_window(
+            "am-feat",
+            Path::new("/tmp/worktree"),
+            &SplitDirection::Horizontal,
+            50,
+            true,
+            Some("podman run --rm -it myimage"),
+        )
+        .unwrap();
+        let out = mock.captured();
+        assert!(out.contains("-b"), "expected -b flag, got: {out}");
+        assert!(
+            out.contains("podman run --rm -it myimage"),
+            "expected shell command alongside -b, got: {out}"
+        );
+    }
+
+    #[test]
+    fn split_window_omits_b_flag_when_not_before() {
+        let mock = MockTmux::new();
+        split_window(
+            "am-feat",
+            Path::new("/tmp/worktree"),
+            &SplitDirection::Horizontal,
+            50,
+            false,
+            None,
+        )
+        .unwrap();
+        let out = mock.captured();
+        assert!(!out.contains("-b"), "expected no -b flag, got: {out}");
     }
 
     #[test]
@@ -318,6 +354,7 @@ mod tests {
             Path::new("/tmp/worktree"),
             &SplitDirection::Horizontal,
             50,
+            false,
             Some("podman run --rm -it myimage"),
         )
         .unwrap();

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -638,6 +638,19 @@ async fn then_tmux_log_contains(world: &mut AmWorld, text: String) {
     );
 }
 
+#[then(expr = "the mock tmux log does not contain {string}")]
+async fn then_tmux_log_does_not_contain(world: &mut AmWorld, text: String) {
+    let log = world
+        .mock_tmux_log
+        .as_ref()
+        .expect("mock tmux was not set up for this scenario");
+    let content = fs::read_to_string(log).unwrap_or_default();
+    assert!(
+        !content.contains(&text),
+        "expected tmux log to NOT contain {text:?}\ngot:\n{content}",
+    );
+}
+
 #[then(expr = "the mock podman log contains {string}")]
 async fn then_podman_log_contains(world: &mut AmWorld, text: String) {
     let log = world

--- a/tests/features/container.feature
+++ b/tests/features/container.feature
@@ -11,7 +11,11 @@ Feature: container integration — session isolation with a container runtime
     Then the command succeeds
     And the output contains "container: am-my-feature"
     And the session file contains "container"
-    And the mock tmux log contains "send-keys"
+    # The container command is handed to split-window rather than typed into a shell with
+    # send-keys, so an over-width line is never redrawn into the agent pane twice.
+    And the mock tmux log contains "split-window"
+    And the mock tmux log contains "am-my-feature"
+    And the mock tmux log does not contain "send-keys"
 
   Scenario: start with --no-container skips container setup
     When I run "am start my-feature --no-container"


### PR DESCRIPTION
## Problem

With `agent_pane = "left"` (the default), the agent stayed in the tmux window's
original pane — which is already an interactive shell — so the container command
had to be typed in with `send-keys`. An interactive shell redraws an over-width
input line, so a several-hundred-character `podman run` rendered **twice** in the
agent pane, and the whole invocation landed in the user's shell history.

With `agent_pane = "right"` the agent was the new pane, so tmux exec'd the command
directly and the problem never appeared. The bug was only ever visible on the default.

## Fix

Make the agent always the pane `split-window` creates, passing `-b` when it belongs
on the left so the new pane is inserted first. tmux then execs the command directly
in every configuration.

- `tmux::split_window` takes a `before: bool` that adds `-b`
- new `pane_layout()` helper replaces the inline mapping in `cmd_start` and `cmd_attach`
- `split_window_shell_cmd` and the `100 - split_percent` inversion are gone — the
  percent now always describes the agent pane
- `send-keys` is kept only for the no-container case, where the command is short and
  leaving a shell behind after the agent exits is useful

Pane indices, the resulting layout, and the meaning of `split_percent` are unchanged,
so existing `sessions.json` records and `am run` / `am attach` targets still resolve.

## Verification

`cargo test` and `cargo clippy -- -D warnings` pass. Checked against a live tmux
session with a stub runtime at 100 columns:

default (agent_pane = left)          AM_TMUX_AGENT_PANE=right SPLIT_PERCENT=30
0 left=0  width=50 cmd=sh   <- agent  0 left=0  width=69 cmd=zsh  <- shell
1 left=51 width=49 cmd=zsh  <- shell  1 left=70 width=30 cmd=sh   <- agent

Both agent panes contain only the container's own output — no echoed command, no
prompt, no second render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)