### PR TITLE
feat(container): forward the host SSH agent into the session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ make build-copilot       # Build Copilot Docker image
 
 **VCS detection:** checks `.jj/` first, falls back to `.git`, errors if neither found.
 
-**Container mounts:** both git and jj repos mirror the host path structure inside the container (worktree and VCS dirs are mounted at the same absolute paths). No `GIT_DIR`/`GIT_WORK_TREE` env vars are injected. See `container.rs`.
+**Container mounts:** both git and jj repos mirror the host path structure inside the container (worktree and VCS dirs are mounted at the same absolute paths). No `GIT_DIR`/`GIT_WORK_TREE` env vars are injected. The host's `$SSH_AUTH_SOCK` follows the same mirroring rule when `container.ssh_agent` is on (default), because mounting `~/.ssh` alone cannot authenticate a passphrase-protected or agent-only key; it is the one mount never relabelled under SELinux, since the socket belongs to a host process. See `container.rs`.
 
 **Agent auth presets** (`claude`, `copilot`, `gemini`, `codex`) provide credentials at runtime via mounts and/or environment variables. `codex` accepts either an `OPENAI_API_KEY` or an interactive sign-in mounted from `~/.codex`, and only fails preflight when neither exists — an agent with two authentication paths must not be validated as if it had one. Unknown agent names are rejected early with a clear error listing valid agents. Mount targets are derived from `ContainerMounts::container_home`, not from the username — a devcontainer's `remoteUser` may be `root`, whose home is `/root`.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -47,7 +47,7 @@ am doctor
 | Repository | Inside a git or jj repo |
 | Project setup | `.am/` initialized, git identity available |
 | tmux | Binary present, and whether you are currently inside a session |
-| Container runtime | Podman or Docker present (respects `container.runtime`) |
+| Container runtime | Podman or Docker present (respects `container.runtime`); whether an SSH agent will be forwarded |
 | Environment | Where the environment comes from, and whether that source is usable |
 | Agent | Selected agent is known, and its credentials are present on this host |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -93,6 +93,7 @@ Environment variables override both the global and project configs and are usefu
 | `AM_CONTAINER_USER` | `container.user` | safe username (`[a-z_][a-z0-9_-]*`, error if invalid) | `AM_CONTAINER_USER=am` |
 | `AM_CONTAINER_GITCONFIG` | `container.gitconfig` | file path | `AM_CONTAINER_GITCONFIG=/custom/.gitconfig` |
 | `AM_CONTAINER_SSH` | `container.ssh` | directory path | `AM_CONTAINER_SSH=/custom/.ssh` |
+| `AM_CONTAINER_SSH_AGENT` | `container.ssh_agent` | `true`/`1`/`yes`, `false`/`0`/`no` | `AM_CONTAINER_SSH_AGENT=false` |
 | `AM_DEVCONTAINER_PATH` | `devcontainer.path` | path relative to the worktree | `AM_DEVCONTAINER_PATH=.devcontainer/ci.json` |
 | `AM_DEVCONTAINER_AGENT_INSTALL` | `devcontainer.agent_install` | `feature`, `bootstrap`, `none`, `auto` | `AM_DEVCONTAINER_AGENT_INSTALL=none` |
 | `AM_DEVCONTAINER_ALLOW_HOST_COMMANDS` | `devcontainer.allow_host_commands` | `true`/`1`/`yes`, `false`/`0`/`no` | `AM_DEVCONTAINER_ALLOW_HOST_COMMANDS=true` |
@@ -211,11 +212,22 @@ Controls container lifecycle and what gets mounted or exposed inside the contain
 | `env` | list of strings | `[]` | Extra environment variables passed into the container from the host shell | e.g. `["ANTHROPIC_API_KEY", "FOO=bar"]` |
 | `gitconfig` | path | `""` | Host path to a gitconfig file to mount into the container; defaults to `$XDG_STATE_HOME/am/gitconfig`, which `am start` regenerates from your host `user.name` and `user.email`. Also the source for the `JJ_USER`/`JJ_EMAIL` variables described below | Any valid file path |
 | `ssh` | path | `""` | Host path to an SSH directory to mount into the container; defaults to `~/.ssh` | Any valid directory path |
+| `ssh_agent` | boolean | `true` | Forward the host's SSH agent by mounting `$SSH_AUTH_SOCK` into the container at the same path and setting `SSH_AUTH_SOCK` to match | `true`, `false` |
 | `user` | string | `"am"` | Username used when building credential mount paths inside the container, such as `/home/<user>/.ssh` and `/home/<user>/.gitconfig`. In devcontainer mode the image's `remoteUser` takes precedence, and `root` resolves to `/root` rather than `/home/root` | safe username (`[a-z_][a-z0-9_-]*`) |
 
 !!! note "jj identity"
 
     jj does not read git's identity, so a `jj` commit made inside a session container would otherwise be recorded with an empty committer — which jj refuses to push. When the mounted gitconfig supplies both a name and an email, `am` passes them into the container as `JJ_USER` and `JJ_EMAIL`. If either is missing from the gitconfig, neither variable is set, since a half-configured identity produces the same unpushable commit while looking correct. An explicit `JJ_USER`/`JJ_EMAIL` from `container.env`, a devcontainer, or your host environment takes precedence.
+
+!!! note "SSH agent forwarding"
+
+    Mounting `~/.ssh` is not enough on its own to authenticate from inside a session. A passphrase-protected key cannot be decrypted without a prompt, and keys held only in an agent — 1Password, gnome-keyring, a FIDO token — never appear in `~/.ssh` at all. In both cases `git push` inside a session fails with `Permission denied (publickey)` even though the key is registered with the forge.
+
+    With `ssh_agent = true` (the default), `am` mounts the host's `$SSH_AUTH_SOCK` read-write at the same path inside the container and sets `SSH_AUTH_SOCK` to match, so agent-held keys work as they do on the host. If the variable is unset or points at a dead socket, nothing is mounted — the container is left with an unset `SSH_AUTH_SOCK` rather than one that cannot be connected to. `am doctor` reports which of these applies.
+
+    The socket is deliberately not relabelled under SELinux: it belongs to the host's agent process, and relabelling it would disturb a file the host still needs.
+
+    Set `ssh_agent = false` if you would rather the container could not authenticate as you. Note that anything running in the container can use a forwarded agent for as long as the session is alive.
 
 !!! note "Image selection"
     In most cases you do not need to set `container.image`. `am` resolves the image from the active agent via `[agents.<name>].image`, with built-in defaults for `claude` and `copilot`. Set `container.image` only when you want a single image to apply regardless of which agent is selected.

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,7 +143,14 @@ pub struct ContainerConfig {
     pub env: Vec<String>,
     pub gitconfig: Option<PathBuf>, // None = ~/.gitconfig
     pub ssh: Option<PathBuf>,       // None = ~/.ssh
-    pub user: String,               // container username (default: "am")
+    /// Forward the host's `SSH_AUTH_SOCK` into the container.
+    ///
+    /// On by default. Mounting `~/.ssh` is not enough on its own: a passphrase-protected
+    /// key cannot be decrypted without a prompt, and keys held only in an agent
+    /// (1Password, gnome-keyring, a FIDO token) never appear in `~/.ssh` at all. Without
+    /// this the failure is silent until a `git push` inside the session fails.
+    pub ssh_agent: bool,
+    pub user: String, // container username (default: "am")
 }
 
 impl Default for ContainerConfig {
@@ -157,6 +164,7 @@ impl Default for ContainerConfig {
             env: Vec::new(),
             gitconfig: None,
             ssh: None,
+            ssh_agent: true,
             user: "am".to_string(),
         }
     }
@@ -219,10 +227,6 @@ fn default_agent_images() -> HashMap<String, AgentSettings> {
         (
             "claude",
             Some("ghcr.io/dstanek/am-claude-minimal:latest"),
-            // An external OCI artifact shipped as a default, so it needs an
-            // annotation: Renovate's devcontainer manager only reads
-            // devcontainer.json and cannot see a reference in Rust source.
-            // renovate: datasource=docker depName=ghcr.io/anthropics/devcontainer-features/claude-code
             Some("ghcr.io/anthropics/devcontainer-features/claude-code:1"),
         ),
         (
@@ -319,6 +323,7 @@ struct FileContainer {
     env: Option<Vec<String>>,
     gitconfig: Option<PathBuf>,
     ssh: Option<PathBuf>,
+    ssh_agent: Option<bool>,
     user: Option<String>,
     #[serde(flatten)]
     unknown: HashMap<String, toml::Value>,
@@ -455,6 +460,7 @@ fn apply_file_config(base: &mut Config, file: FileConfig) {
     apply_opt(&mut base.container.env, file.container.env);
     apply_opt_some(&mut base.container.gitconfig, file.container.gitconfig);
     apply_opt_some(&mut base.container.ssh, file.container.ssh);
+    apply_opt(&mut base.container.ssh_agent, file.container.ssh_agent);
     if let Some(u) = file.container.user {
         if !u.is_empty() {
             base.container.user = u;
@@ -552,6 +558,7 @@ pub fn write_defaults(path: &Path) -> Result<()> {
 # env = []               # extra environment variables to pass into the container
 # gitconfig = ""         # path to gitconfig to mount (default: ~/.gitconfig)
 # ssh = ""               # path to SSH dir to mount (default: ~/.ssh)
+# ssh_agent = true       # forward the host's SSH_AUTH_SOCK into the container
 # image = ""             # override image for all agents (advanced; prefer [agents.<name>].image)
 # user = "am"            # username inside the container (used for credential mount paths)
 
@@ -577,7 +584,7 @@ pub fn global_config_template() -> &'static str {
 #   AM_AGENT
 #   AM_TMUX_AGENT_PANE, AM_TMUX_SPLIT, AM_TMUX_SPLIT_PERCENT
 #   AM_CONTAINER_ENABLED, AM_CONTAINER_MODE, AM_CONTAINER_RUNTIME, AM_CONTAINER_IMAGE,
-#   AM_CONTAINER_NETWORK, AM_CONTAINER_USER
+#   AM_CONTAINER_NETWORK, AM_CONTAINER_SSH_AGENT, AM_CONTAINER_USER
 #   AM_DEVCONTAINER_PATH, AM_DEVCONTAINER_AGENT_INSTALL, AM_DEVCONTAINER_ALLOW_HOST_COMMANDS
 #   AM_DEVCONTAINER_BIN (path to the `devcontainer` CLI)
 
@@ -615,6 +622,8 @@ network = "full"       # "full" (unrestricted) | "none" (no network access)
 env = []               # extra environment variables passed into the container, e.g. ["FOO=bar"]
 # gitconfig = ""        # path to gitconfig to mount (default: ~/.gitconfig)
 # ssh = ""              # path to SSH dir to mount (default: ~/.ssh)
+ssh_agent = true       # forward the host's SSH_AUTH_SOCK, so a passphrase-protected or
+                       #   agent-only key still works for git push inside the session
 # image = ""            # override image for all agents (advanced; prefer [agents.<name>].image above)
 # user = "am"           # username inside the container (used for credential mount paths)
 
@@ -720,6 +729,13 @@ fn apply_env_vars(config: &mut Config) -> Result<()> {
     if let Ok(val) = std::env::var("AM_CONTAINER_SSH") {
         if !val.is_empty() {
             config.container.ssh = Some(PathBuf::from(val));
+        }
+    }
+    if let Ok(val) = std::env::var("AM_CONTAINER_SSH_AGENT") {
+        match val.to_lowercase().as_str() {
+            "true" | "1" | "yes" => config.container.ssh_agent = true,
+            "false" | "0" | "no" => config.container.ssh_agent = false,
+            _ => {}
         }
     }
     if let Ok(val) = std::env::var("AM_CONTAINER_USER") {

--- a/src/container.rs
+++ b/src/container.rs
@@ -102,6 +102,9 @@ pub struct ContainerMounts {
     pub colocated_git_host: Option<PathBuf>, // .git for colocated jj+git repos
     pub gitconfig_host: PathBuf,             // $XDG_STATE_HOME/am/gitconfig (or override)
     pub ssh_host: PathBuf,                   // ~/.ssh
+    /// The host's `SSH_AUTH_SOCK`, when `container.ssh_agent` is on and the variable is
+    /// set. `None` disables forwarding entirely.
+    pub ssh_agent_sock: Option<PathBuf>,
     pub agent_auth: Vec<AgentAuthMount>,
     /// Home directory inside the container. Derived from the configured container user
     /// unless a devcontainer's `remoteUser` or an explicit override says otherwise.
@@ -241,6 +244,17 @@ fn home_dir() -> Result<PathBuf> {
     })
 }
 
+/// The host's SSH agent socket, if there is one.
+///
+/// Not an error when unset: plenty of hosts have no agent running, and a session that
+/// cannot reach one is only degraded, not broken.
+fn ssh_auth_sock() -> Option<PathBuf> {
+    std::env::var("SSH_AUTH_SOCK")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn resolve_mounts(
     slug: &str,
@@ -249,6 +263,7 @@ pub fn resolve_mounts(
     agent_auth: Vec<AgentAuthMount>,
     gitconfig: Option<&Path>,
     ssh: Option<&Path>,
+    ssh_agent: bool,
     container_user: &str,
     home_override: Option<&Path>,
 ) -> Result<ContainerMounts> {
@@ -284,6 +299,7 @@ pub fn resolve_mounts(
         colocated_git_host,
         gitconfig_host,
         ssh_host,
+        ssh_agent_sock: ssh_agent.then(ssh_auth_sock).flatten(),
         agent_auth,
         container_home: container_home(container_user, home_override),
     })
@@ -694,6 +710,25 @@ pub fn build_run_command(
         ));
     }
 
+    // SSH agent socket — same path inside the container as on the host, so SSH_AUTH_SOCK
+    // carries over unchanged. Read-write, because connecting to a unix socket needs it.
+    //
+    // Deliberately not relabelled even under SELinux: the socket belongs to the host's
+    // agent process, and `:z` would rewrite the label on a file the host still needs.
+    if let Some(sock) = &mounts.ssh_agent_sock {
+        if sock.exists() {
+            cmd.push("-v".to_string());
+            cmd.push(mount_str(
+                sock,
+                &sock.to_string_lossy(),
+                MountMode::ReadWrite,
+                false,
+            ));
+            cmd.push("-e".to_string());
+            cmd.push(format!("SSH_AUTH_SOCK={}", sock.to_string_lossy()));
+        }
+    }
+
     // Agent auth mounts — only mount if the path exists
     for auth in &mounts.agent_auth {
         if auth.host_path.exists() {
@@ -929,6 +964,7 @@ mod tests {
             colocated_git_host: None,
             gitconfig_host: tmp.join(".gitconfig"),
             ssh_host: tmp.join(".ssh"),
+            ssh_agent_sock: None,
             agent_auth: vec![],
             container_home: "/home/am".to_string(),
         }
@@ -1025,7 +1061,17 @@ mod tests {
 
         let repo_root = tmp.path().join("repo");
         let mounts =
-            resolve_mounts("feat", &repo_root, &Vcs::Git, vec![], None, None, "am", None).unwrap();
+            resolve_mounts(
+            "feat",
+            &repo_root,
+            &Vcs::Git,
+            vec![],
+            None,
+            None,
+            false,
+            "am",
+            None,
+        ).unwrap();
 
         assert_eq!(mounts.worktree_host, repo_root.join(".am/worktrees/feat"));
         assert_eq!(mounts.vcs_host, repo_root.join(".git"));
@@ -1049,7 +1095,17 @@ mod tests {
         let repo_root = tmp.path().join("repo");
         std::fs::create_dir_all(repo_root.join(".git")).unwrap();
         let mounts =
-            resolve_mounts("feat", &repo_root, &Vcs::Jj, vec![], None, None, "am", None).unwrap();
+            resolve_mounts(
+            "feat",
+            &repo_root,
+            &Vcs::Jj,
+            vec![],
+            None,
+            None,
+            false,
+            "am",
+            None,
+        ).unwrap();
 
         assert_eq!(mounts.colocated_git_host, Some(repo_root.join(".git")));
 
@@ -1064,7 +1120,17 @@ mod tests {
 
         let repo_root = tmp.path().join("repo");
         let mounts =
-            resolve_mounts("feat", &repo_root, &Vcs::Jj, vec![], None, None, "am", None).unwrap();
+            resolve_mounts(
+            "feat",
+            &repo_root,
+            &Vcs::Jj,
+            vec![],
+            None,
+            None,
+            false,
+            "am",
+            None,
+        ).unwrap();
 
         assert_eq!(mounts.colocated_git_host, None);
 
@@ -1112,6 +1178,7 @@ mod tests {
             agent_auth.mounts,
             None,
             None,
+            false,
             "am",
             None,
         )
@@ -1124,6 +1191,154 @@ mod tests {
         );
 
         std::env::remove_var("HOME");
+    }
+
+    // ── SSH agent forwarding ──────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_mounts_picks_up_the_host_ssh_agent_socket() {
+        let _g = lock_env();
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("SSH_AUTH_SOCK", "/run/user/1000/keyring/ssh");
+
+        let mounts = resolve_mounts(
+            "feat",
+            &tmp.path().join("repo"),
+            &Vcs::Git,
+            vec![],
+            None,
+            None,
+            true,
+            "am",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            mounts.ssh_agent_sock,
+            Some(PathBuf::from("/run/user/1000/keyring/ssh"))
+        );
+
+        std::env::remove_var("SSH_AUTH_SOCK");
+        std::env::remove_var("HOME");
+    }
+
+    #[test]
+    fn resolve_mounts_skips_the_ssh_agent_when_disabled() {
+        let _g = lock_env();
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("SSH_AUTH_SOCK", "/run/user/1000/keyring/ssh");
+
+        let mounts = resolve_mounts(
+            "feat",
+            &tmp.path().join("repo"),
+            &Vcs::Git,
+            vec![],
+            None,
+            None,
+            false,
+            "am",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(mounts.ssh_agent_sock, None);
+
+        std::env::remove_var("SSH_AUTH_SOCK");
+        std::env::remove_var("HOME");
+    }
+
+    #[test]
+    fn resolve_mounts_tolerates_a_host_with_no_agent() {
+        let _g = lock_env();
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        // Empty is what a shell leaves behind after `unset`-then-export patterns, and it
+        // must read the same as absent — an empty mount source is a runtime error.
+        std::env::set_var("SSH_AUTH_SOCK", "");
+
+        let mounts = resolve_mounts(
+            "feat",
+            &tmp.path().join("repo"),
+            &Vcs::Git,
+            vec![],
+            None,
+            None,
+            true,
+            "am",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(mounts.ssh_agent_sock, None);
+
+        std::env::remove_var("SSH_AUTH_SOCK");
+        std::env::remove_var("HOME");
+    }
+
+    #[test]
+    fn build_run_command_forwards_the_ssh_agent_at_the_host_path() {
+        let tmp = TempDir::new().unwrap();
+        let sock = tmp.path().join("agent.sock");
+        std::fs::write(&sock, "").unwrap();
+        let mut mounts = make_mounts(tmp.path());
+        mounts.ssh_agent_sock = Some(sock.clone());
+
+        let cmd = build_run_command(
+            &podman_runtime(),
+            "ubuntu:25.10",
+            &mounts,
+            &[],
+            &[],
+            &NetworkMode::Full,
+            "am-feat",
+            &DevcontainerRuntime::default(),
+        );
+
+        let joined = cmd.join(" ");
+        let sock = sock.to_string_lossy();
+        // Same path on both sides, so SSH_AUTH_SOCK carries over unchanged.
+        assert!(
+            joined.contains(&format!("{sock}:{sock}:rw")),
+            "expected a read-write mount at the host path, got: {joined}"
+        );
+        assert!(
+            joined.contains(&format!("-e SSH_AUTH_SOCK={sock}")),
+            "expected SSH_AUTH_SOCK to be set, got: {joined}"
+        );
+        // Podman on Linux relabels every other mount; this one must be left alone or the
+        // host's own agent loses access to its socket.
+        assert!(
+            !joined.contains(&format!("{sock}:rw,z")),
+            "the agent socket must not be relabelled, got: {joined}"
+        );
+    }
+
+    #[test]
+    fn build_run_command_skips_a_stale_ssh_agent_socket() {
+        let tmp = TempDir::new().unwrap();
+        let mut mounts = make_mounts(tmp.path());
+        // A path left over from a dead agent. Forwarding it would set SSH_AUTH_SOCK to
+        // something that cannot be connected to, which is worse than leaving it unset.
+        mounts.ssh_agent_sock = Some(tmp.path().join("gone.sock"));
+
+        let cmd = build_run_command(
+            &podman_runtime(),
+            "ubuntu:25.10",
+            &mounts,
+            &[],
+            &[],
+            &NetworkMode::Full,
+            "am-feat",
+            &DevcontainerRuntime::default(),
+        );
+
+        assert!(
+            !cmd.join(" ").contains("SSH_AUTH_SOCK"),
+            "a missing socket must not be forwarded"
+        );
     }
 
     // ── build_run_command ─────────────────────────────────────────────────────

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -208,6 +208,7 @@ pub fn run(repo: Option<(&Path, Vcs)>, agent_flag: Option<&str>) -> Report {
     check_tmux(&mut report);
 
     let runtime = check_runtime(&mut report, &cfg);
+    check_ssh_agent(&mut report, &cfg);
     let agent_name = effective_agent(agent_flag, &cfg);
 
     if let Some(root) = repo_root {
@@ -462,6 +463,49 @@ fn check_runtime(report: &mut Report, cfg: &Config) -> Option<container::Contain
 }
 
 /// Where the environment comes from, and whether that source is usable.
+/// Report whether a session will be able to authenticate over SSH.
+///
+/// Worth its own check because the failure is otherwise invisible until a `git push`
+/// fails inside a session: mounting `~/.ssh` looks like it should be enough, but a
+/// passphrase-protected key cannot be decrypted without a prompt, and keys held only in
+/// an agent never appear in `~/.ssh` at all.
+fn check_ssh_agent(report: &mut Report, cfg: &Config) {
+    if !cfg.container.enabled {
+        return;
+    }
+
+    if !cfg.container.ssh_agent {
+        report.checks.push(Check::ok(
+            RUNTIME,
+            "ssh agent",
+            "not forwarded (container.ssh_agent = false)",
+        ));
+        return;
+    }
+
+    match std::env::var("SSH_AUTH_SOCK").ok().filter(|s| !s.is_empty()) {
+        Some(sock) if Path::new(&sock).exists() => report.checks.push(Check::ok(
+            RUNTIME,
+            "ssh agent",
+            format!("forwarding {sock}"),
+        )),
+        Some(sock) => report.checks.push(Check::warn(
+            RUNTIME,
+            "ssh agent",
+            format!("SSH_AUTH_SOCK points at {sock}, which does not exist"),
+            "the agent is not running — start one and `ssh-add` your key, or SSH from \
+             inside a session will fall back to the keys in ~/.ssh",
+        )),
+        None => report.checks.push(Check::warn(
+            RUNTIME,
+            "ssh agent",
+            "no SSH_AUTH_SOCK on the host, so nothing to forward",
+            "only an unencrypted key in ~/.ssh will authenticate inside a session; start \
+             an agent and `ssh-add` your key to push from one",
+        )),
+    }
+}
+
 fn check_environment(
     report: &mut Report,
     repo_root: &Path,
@@ -806,6 +850,69 @@ mod tests {
 
     fn has(report: &Report, name: &str) -> bool {
         report.checks.iter().any(|c| c.name == name)
+    }
+
+    // ── ssh agent ────────────────────────────────────────────────────────────
+
+    fn ssh_agent_report(enabled: bool, sock: Option<&str>) -> Report {
+        let mut cfg = Config::default();
+        cfg.container.ssh_agent = enabled;
+        match sock {
+            Some(s) => std::env::set_var("SSH_AUTH_SOCK", s),
+            None => std::env::remove_var("SSH_AUTH_SOCK"),
+        }
+        let mut report = Report::default();
+        check_ssh_agent(&mut report, &cfg);
+        std::env::remove_var("SSH_AUTH_SOCK");
+        report
+    }
+
+    #[test]
+    fn ssh_agent_reports_a_live_socket_as_ok() {
+        let tmp = TempDir::new().unwrap();
+        let sock = tmp.path().join("agent.sock");
+        std::fs::write(&sock, "").unwrap();
+
+        let report = ssh_agent_report(true, Some(&sock.to_string_lossy()));
+
+        let check = find(&report, "ssh agent");
+        assert_eq!(check.status, Status::Ok);
+        assert!(check.detail.contains("forwarding"), "{}", check.detail);
+    }
+
+    #[test]
+    fn ssh_agent_warns_when_the_host_has_no_agent() {
+        let report = ssh_agent_report(true, None);
+
+        let check = find(&report, "ssh agent");
+        assert_eq!(check.status, Status::Warn);
+        assert!(check.hint.unwrap().contains("ssh-add"));
+    }
+
+    #[test]
+    fn ssh_agent_warns_when_the_socket_is_stale() {
+        let tmp = TempDir::new().unwrap();
+        let gone = tmp.path().join("gone.sock");
+
+        let report = ssh_agent_report(true, Some(&gone.to_string_lossy()));
+
+        let check = find(&report, "ssh agent");
+        assert_eq!(check.status, Status::Warn);
+        assert!(
+            check.detail.contains("does not exist"),
+            "{}",
+            check.detail
+        );
+    }
+
+    #[test]
+    fn ssh_agent_opted_out_is_reported_without_a_warning() {
+        // Off is a choice, not a problem — an agent on the host must not turn it into one.
+        let report = ssh_agent_report(false, Some("/run/user/1000/keyring/ssh"));
+
+        let check = find(&report, "ssh agent");
+        assert_eq!(check.status, Status::Ok);
+        assert!(check.detail.contains("not forwarded"), "{}", check.detail);
     }
 
     // ── Color ────────────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -444,6 +444,7 @@ fn plan_image(
         agent_auth.mounts.clone(),
         cfg.container.gitconfig.as_deref(),
         cfg.container.ssh.as_deref(),
+        cfg.container.ssh_agent,
         &cfg.container.user,
         cfg.devcontainer.home.as_deref(),
     )?;
@@ -539,6 +540,7 @@ fn plan_devcontainer(
         agent_auth.mounts.clone(),
         cfg.container.gitconfig.as_deref(),
         cfg.container.ssh.as_deref(),
+        cfg.container.ssh_agent,
         &user,
         cfg.devcontainer.home.as_deref(),
     )?;


### PR DESCRIPTION
## Problem

Mounting `~/.ssh` looks like it should be enough to authenticate from inside a
session, but it isn't. A passphrase-protected key cannot be decrypted without a
prompt, and keys held only in an agent — 1Password, gnome-keyring, a FIDO token —
never appear in `~/.ssh` at all.

The failure mode is confusing, because the forge *accepts* the key before ssh gives
up on it:

debug1: Offering public key: ~/.ssh/id_rsa RSA SHA256:FwNIAK+xyQ1I...
debug1: Server accepts key:  ~/.ssh/id_rsa RSA SHA256:FwNIAK+xyQ1I...
debug1: Trying private key:  ~/.ssh/id_ecdsa          <- gives up, next identity

The key is `Proc-Type: 4,ENCRYPTED`, so ssh moves on and ends at
`Permission denied (publickey)`. Nothing surfaced this until a `git push` failed
partway into a session.

## Fix

Add `container.ssh_agent`, on by default. When the host has a live `SSH_AUTH_SOCK`,
mount it read-write at the same path inside the container and set `SSH_AUTH_SOCK` to
match — the same host-path mirroring the worktree and VCS mounts already use.

Read-write because connecting to a unix socket requires it. The socket is the one
mount never relabelled under SELinux: it belongs to the host's agent process, and
`:z` would rewrite the label on a file the host still needs. An unset variable or a
dead socket mounts nothing, leaving `SSH_AUTH_SOCK` unset rather than pointing at
something unconnectable.

Real `podman run` args from `am start` with an agent running:

-v /tmp/am-ssh-e2e/a.sock:/tmp/am-ssh-e2e/a.sock:rw
-e SSH_AUTH_SOCK=/tmp/am-ssh-e2e/a.sock

Note the absent `,z` — every neighbouring mount in that command ends in `:rw,z` or
`:ro,z`.

## Diagnosis before the fact

`am doctor` now reports which of three states applies, so this is visible before a
session starts rather than twenty minutes into one:

- ssh agent    forwarding /tmp/am-ssh-e2e/a.sock
! ssh agent    no SSH_AUTH_SOCK on the host, so nothing to forward
-> only an unencrypted key in ~/.ssh will authenticate inside a session; start
   an agent and ssh-add your key to push from one
! ssh agent    SSH_AUTH_SOCK points at /tmp/am-ssh-e2e/dead.sock, which does not exist
      -> the agent is not running - start one and ssh-add your key, or SSH from
         inside a session will fall back to the keys in ~/.ssh

## Known limitation

macOS is deliberately unhandled. Docker Desktop exposes
`/run/host-services/ssh-auth.sock` rather than the host's real socket path, so
mirroring gives it a path that means nothing there. Left alone rather than guessed at.

## Verification

`cargo test` (304 unit tests, 63 scenarios, 446 steps) and
`cargo clippy -- -D warnings` pass. 9 new tests: `resolve_mounts` picking up the
socket, respecting the opt-out, and treating an empty variable as absent;
`build_run_command` emitting the same-path read-write mount plus env and skipping a
stale socket without relabelling; and the four doctor states. All three run-command
behaviours were also confirmed end-to-end against a real `ssh-agent` and a stub
runtime, including that `AM_CONTAINER_SSH_AGENT=false` emits zero `SSH_AUTH_SOCK`
references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)