### PR TITLE
feat(attach): restore the agent and its conversation on attach

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,110 @@ Outstanding work for `am`. Items are grouped by theme and roughly ordered by pri
 
 ---
 
+## Session Recovery
+
+### Restore the Agent on `am attach`
+> Spec: [`specs/attach-restore-agent.md`](specs/attach-restore-agent.md)
+
+**Done.** Before this, `am attach` only ever restored the tmux *window* — a reboot survives at
+the worktree and session-record level, but tmux and the agent process do not, and `am attach`
+recreated an empty window (or, for a container session, printed a `Note:` telling you to run
+`am destroy --force <slug> && am start <slug>` by hand instead of fixing it).
+
+`Session.agent` is now recorded by `am start` and kept current by `am run`, so `am attach` knows
+what to relaunch. `am attach` checks the pane's actual state (`tmux::pane_current_command`,
+biased hard toward "still running" on any ambiguity — a missed relaunch costs an `am run`, an
+unwanted one can interrupt live work) and does the least work needed to fix it: an already-live
+session is an unchanged, instant no-op; a live window with an idle agent pane gets a
+`send-keys` relaunch in place; a fully gone window gets recreated (window, split, and — for a
+containerized session — the container itself, via a container-planning helper shared with `am
+start` so the two can't drift apart) before the agent is relaunched into it. Resume is on by
+default (`--continue` for Claude/Copilot, `--resume latest` for Gemini, `resume --last` for
+Codex, each verified against the CLI's own `--help`), with `am attach --fresh` and
+`[attach].resume = false` as opt-outs. A legacy record with no agent falls back to `cfg.agent`
+and persists the resolved value; if neither is available, `am` says so and points at `am run`.
+
+Two accepted trade-offs: recreating a container re-runs `am start`'s own preflight (credential
+validation, an image rebuild if pruned), so attach can now be as slow as, and fail the same ways
+as, `am start` — only when the container is genuinely gone. And if that preflight fails, the
+early return skips the shell-pane selection, so you land on the agent pane rather than the shell
+pane; the window and split are created first, so a retry has something real to act on.
+
+`cargo test` (528 unit tests + 120 cucumber scenarios) and
+`cargo clippy --all-targets -- -D warnings` both clean.
+
+Deferred code-review suggestions, not dropped:
+
+- [ ] The host relaunch path writes the session record twice
+      (`session::update_session_global`) where once would do — a redundant file write and lock
+      acquisition in the common case, harmless but avoidable.
+- [ ] A failed container-recreate preflight leaves focus on the agent pane instead of the shell
+      pane (see above) — the early return skips `select_pane`. Cosmetic; a retry corrects it.
+- [ ] `agent_command` appends auto flags before resume flags; harmless today because no agent
+      combines a non-empty `agent_auto_flags` with a subcommand-shaped resume form (like
+      Codex's `resume --last`, which must be the first token), but latent breakage for a future
+      agent that has both. Already flagged with an in-code comment at the call site.
+
+### Credential preflight checks presence, not validity
+
+**Open.** `container::validate_agent_credentials` only checks that an agent's credential *path*
+exists. An expired, revoked, or logged-out credential leaves that path in place, so preflight
+passes and `am` reports success while the agent fails to authenticate inside the pane. Per agent,
+the entire check is:
+
+| Agent | What is checked |
+|---|---|
+| Claude | `$CLAUDE_CONFIG_DIR`, else `~/.claude`, exists |
+| Copilot | `~/.config/gh` exists |
+| Gemini | `~/.gemini` exists |
+| Codex | `~/.codex/auth.json` exists, **or** `OPENAI_API_KEY` is set and non-empty |
+
+This is pre-existing behaviour inherited from `am start` — `am attach`'s container recreate
+reuses the same preflight via `plan_container_runtime`. What is new is that `am attach` now
+reaches this path at all, and that its success line actively asserts a recovery that may not have
+happened.
+
+**How to reach the broken state.** With a containerized session (`container.enabled = true`):
+
+1. `am start feat --agent claude`. The record gets `agent = "claude"` and a `SessionContainer`.
+2. Let the credential expire or revoke it — sign out on another machine, or simply wait out the
+   token lifetime. **Do not delete `~/.claude`**; sign-out and expiry both leave the directory
+   behind, and that is the entire point of the bug.
+3. Reboot, or otherwise kill tmux and the container. The worktree and `sessions.json` survive.
+4. `am attach feat`.
+
+Observed: `select_window` fails, so `recreate_attach_window` creates the window and split,
+persists the pane targets, and calls `attach_recreate_container_cmd` →
+`plan_container_runtime` → `validate_agent_credentials(Claude)` →
+`ensure_required_paths(&[~/.claude])`. The path exists, so the check passes. The run command is
+built and `send_keys`'d into the pane, and `am` prints
+
+```
+Opened new window for session 'feat' and restarted the container.
+```
+
+and exits `0`. The container starts, `claude --continue` runs inside it, and the authentication
+failure surfaces only as agent output in the pane — never as an `am` error, and never in the exit
+status. Anything scripting `am attach` sees a clean success.
+
+Contrast with the cases preflight *does* catch, which fail loudly and are recoverable: a
+container runtime that is not up yet (the common post-reboot case, caught by `detect_runtime`)
+or a credential directory that is genuinely absent. Both error after the window and split exist,
+and a retry after fixing the cause goes through `relaunch_into_existing_window` — the pane reads
+as a bare shell, so `agent_pane_status` returns `Idle` — and completes normally.
+
+Possible directions, none obviously right:
+
+- [ ] Have `am doctor` check credential *validity* rather than presence, and point `am attach` at
+      it on failure. Requires a per-agent liveness probe, which is agent-CLI-specific and may
+      require a network round-trip.
+- [ ] Do not claim recovery in the success line when `am` cannot confirm the agent came up —
+      soften `... and restarted the container.` to describe what was actually done.
+- [ ] Accept and document only. The failure is visible in the pane the user is looking at; the
+      real exposure is scripted/unattended use.
+
+---
+
 ## Agent Integrations
 
 ### Feature 7: Codex Integration
@@ -417,6 +521,10 @@ Follow-ups phase 1 left behind:
 - [ ] `postAttachCommand` is never run — `am attach` moves tmux focus rather than attaching
       to the container, so there is no attach event to hang it off. Needs a real
       "exec into the running container" attach path.
+      ([Restore the Agent on `am attach`](#restore-the-agent-on-am-attach) makes `am attach`
+      recreate a container that is genuinely gone — rerunning its create-time lifecycle hooks
+      via the same `lifecycle_done` bookkeeping `am start` uses — but that is not the same as
+      attaching to one that is already running; this gap is still open.)
 - [ ] Create-time lifecycle hooks re-run on every `am start` because containers are `--rm`.
       Correct given ephemeral containers, but a persistent-container mode would make the
       spec's once-per-container semantics achievable; `lifecycle_done` already records what

--- a/docs/guides/session-lifecycle.md
+++ b/docs/guides/session-lifecycle.md
@@ -60,24 +60,43 @@ container launch — the worktree may be left behind without a session record. U
 `am attach` is a tmux-only command. For sessions started without tmux (the first and third
 rows of the table for each VCS), it exits with an error.
 
-For sessions that have a tmux window, `am attach` handles three situations:
+For sessions that have a tmux window, `am attach` handles four situations:
 
-1. **Navigation** — the window exists; `am attach` switches your tmux focus to it.
-2. **Window recovery** — the window was closed; `am attach` creates a new split window and
-   shell pane for the session.
-3. **Deferred open** — you ran `am start` outside of tmux and later want a split window;
-   `am attach` from inside tmux creates it.
+1. **Navigation** — the window exists and the agent (or, for a container session, the
+   container) is confidently still running; `am attach` just switches your tmux focus to it.
+2. **In-place relaunch** — the window exists but the agent pane is confidently idle (the agent
+   exited, or the container's foreground process died, which also ends the container); `am
+   attach` relaunches the recorded agent — or recreates the container — directly into the
+   existing pane.
+3. **Window recovery** — the window is gone entirely, most commonly because the machine
+   rebooted; `am attach` recreates the window and split, then relaunches the agent (recreating
+   the container first, for a containerized session) into the fresh agent pane.
+4. **Deferred open** — you ran `am start` outside of tmux and later want a split window; `am
+   attach` from inside tmux creates it the same way window recovery does.
+
+By default, a relaunch also asks the agent to resume its previous conversation (`--continue`
+for Claude/Copilot, `--resume latest` for Gemini, `resume --last` for Codex). Pass `--fresh`,
+or set `resume = false` under `[attach]` in config, to start cold instead.
 
 **Container sessions and window recovery:** containers run with `--rm -it`, so when a tmux
 pane closes (killing the container process), the container stops and is automatically removed.
-If you run `am attach` after the window has been closed, it creates a fresh empty agent pane
-but the container is gone. `am attach` prints a hint in this case:
+`am attach` detects this and recreates the container — re-running the same preflight `am start`
+does (runtime detection, credential validation, and, in devcontainer mode, an image rebuild if
+the previous image was pruned) — before handing the rebuilt run command to the fresh agent pane:
 
 ```
-Opened new window for session 'feat'.
-  Note: the container was stopped when the window closed.
-  To restart cleanly: am destroy --force feat && am start feat
+Opened new window for session 'feat' and restarted the container.
 ```
+
+Because that preflight is real work, it can fail the same way `am start`'s can — a container
+runtime that isn't running yet, a missing credential directory. If it does, the window and split
+from step 3 above are still left in place (so you have something to retry against) and reported
+as an error; fix the underlying problem and re-run `am attach` to pick up where it left off.
+
+Note that preflight only checks that a credential *path* exists, not that the credential is
+still valid — an expired token passes preflight, and `am attach` reports success while the agent
+fails to authenticate inside the pane. See
+[`am attach`](../reference/commands.md#am-attach-slug) for the full set of output messages.
 
 ### `am destroy`
 
@@ -111,7 +130,9 @@ Run `am destroy <slug>` from your host shell to remove the worktree and clean up
 record. If the exec itself failed, the session was already recorded — use
 `am destroy --force <slug>` to remove it without touching the (non-existent) worktree.
 
-`am attach` is not available for sessions started this way, since there is no tmux window.
+No tmux window was ever recorded for a session started this way, but `am attach <slug>` from
+inside a tmux session still works — same as "Deferred open" above, it creates the window (and,
+for a container session, relaunches the agent into a recreated container) on the spot.
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -402,29 +402,93 @@ bugfix  —          —     /home/user/proj/.am/worktrees/bugfix am-bugfix 2026
 
 ## `am attach <slug>`
 
-Attach to an existing session's tmux window.
+Switch to an existing session's tmux window, restoring the agent — and, for a containerized
+session, the container itself — if either isn't running anymore.
 
 **Usage**
 
 ```sh
-am attach <slug>
+am attach <slug> [--fresh]
 ```
 
-Switches the current tmux client to the `am-<slug>` window. If the window does not exist (for example, after a system restart), `am attach` creates a new window and split for the session — it does not error.
+**Options**
+
+| Option | Description |
+|---|---|
+| `--fresh` | Skip resuming the previous conversation for this invocation only; relaunch with a fresh conversation regardless of `[attach].resume`. |
+
+The motivating case is a machine reboot: the git worktree (or jj workspace) and the session
+record both survive, but tmux and the agent process do not. `am attach` now fixes that in one
+command instead of leaving you with an empty window.
+
+**What it does**
+
+`am attach` checks the state the session is actually in and does the least work needed to fix it:
+
+1. **Window open, agent still running** (the common case) — switches to the window. No relaunch, no container work, just one tmux query to confirm the agent pane's foreground process is what it should be. Prints `Attached to session '<slug>'.`
+2. **Window open, but the agent pane went idle** (the agent crashed, was killed, or exited) — relaunches the recorded agent (or restarts the container, for a container session) directly into the existing pane via `send-keys`; the window and split are untouched. Prints `Attached to session '<slug>'; agent had exited — relaunched '<agent>' (resuming).` (containerized: `; container had exited — restarted it.`)
+3. **Window is gone entirely** — recreates the window and split, then relaunches the agent into the fresh agent pane; for a containerized session, recreates the container first and hands the run command to the split. Prints `Opened new window for session '<slug>' and relaunched '<agent>' (resuming).` (containerized: `and restarted the container.`)
+
+Deciding a pane is idle is deliberately conservative: if the foreground process can't be
+confidently matched to either the recorded agent/container or a bare shell — an unrecognized
+process name, a failed tmux query, a pane target that's gone — `am attach` treats it as still
+running and does nothing. A missed relaunch just costs you an `am run`; relaunching on top of a
+live agent could interrupt real work.
+
+**Which agent gets relaunched.** Whatever `am start --agent <agent>` or the most recently run
+`am run <slug> <agent>` launched into the session — `am run` updates the recorded agent on
+success, so attach always relaunches what actually ran last. Session records written before
+this feature existed have no agent on file; `am attach` falls back to the current `agent` from
+config and remembers that choice for next time. If there's no configured agent either, it opens
+the window/pane with nothing launched and adds:
+
+```
+Note: am attach does not know which agent to launch — run 'am run <slug> <agent>'
+```
+
+**Resuming the previous conversation.** By default, a relaunch asks the agent to resume its
+previous conversation instead of starting cold — `--continue` for Claude and Copilot,
+`--resume latest` for Gemini, `resume --last` for Codex. Skip it for one invocation with
+`am attach <slug> --fresh`, or by default with `resume = false` under `[attach]` in config (see
+[Configuration](configuration.md#attach)). Whether resume actually finds a conversation to pick
+up is entirely up to the agent CLI — `am` only forwards the flag.
+
+**Recreating a container.** Because the container is genuinely gone, recreating it re-runs the
+same preflight `am start` does — runtime detection, credential validation, and, in devcontainer
+mode, an image rebuild if the previously built image no longer exists. That means this path can
+be as slow as `am start`, and can fail the same ways: a container runtime that isn't running
+(common right after a reboot, before the podman/docker service comes up), a missing credential
+directory, a devcontainer config that no longer builds. The window and split are created first,
+so a preflight failure leaves you with a real, addressable window rather than a dead end — the
+error is reported, and re-running `am attach` after fixing the underlying problem picks up where
+it left off. This is a deliberate trade for actually fixing the reboot case; the already-running
+fast path (state 1 above) is unaffected and stays instant.
+
+!!! warning "An expired credential is not caught by preflight"
+    Credential preflight only checks that the agent's credential *path* exists — `~/.claude`
+    (or `$CLAUDE_CONFIG_DIR`), `~/.config/gh`, `~/.gemini`, `~/.codex/auth.json` or a non-empty
+    `OPENAI_API_KEY`. An expired or revoked token leaves that path in place, so preflight
+    passes, `am attach` reports `... and restarted the container.`, and the authentication
+    failure appears only as agent output inside the pane — `am` still exits `0`. If you script
+    `am attach`, do not read its exit status as "the agent is working."
+
+!!! note "Which pane has focus after a failed container preflight"
+    A preflight failure returns before `am` selects the shell pane, so you land on the agent
+    pane rather than the shell pane. The new window itself is focused either way.
 
 **Example output**
 
-When the window is recreated for a session that has a container, a `Note:` call-out follows,
-with a dimmed line underneath it showing how to restart cleanly:
-
 ```
-Opened new window for session 'demo'.
-  Note: the container was stopped when the window closed.
-  To restart cleanly: am destroy --force demo && am start demo
+Opened new window for session 'demo' and relaunched 'claude' (resuming).
 ```
 
-The `Note:` line uses the same yellow severity as every other note in `am`. If the window already
-exists, `am attach` just switches to it and prints `Attached to session '<slug>'.` with no detail.
+```
+Attached to session 'demo'; agent had exited — relaunched 'claude' (resuming).
+```
+
+```
+Opened new window for session 'demo' and restarted the container.
+```
 
 !!! warning "Requires tmux"
     `am attach` must be run from inside a tmux session. If `$TMUX` is not set, the command exits with an error. To get a terminal inside an existing session without tmux, navigate directly to `.am/worktrees/<slug>`.
@@ -442,6 +506,8 @@ am run <slug> <agent>
 ```
 
 Uses `tmux send-keys` to send the specified agent command to the agent pane of the `am-<slug>` window, followed by Enter. This is useful for (re)starting an agent in a session that was started without one, or after the agent process has exited.
+
+On success, `am run` also records `<agent>` as the session's agent, so a later [`am attach`](#am-attach-slug) relaunches whatever was actually run last rather than whatever `am start` originally recorded.
 
 **Example**
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -161,6 +161,12 @@ The `am start` command accepts flags that act as the highest-precedence override
 | `--agent <AGENT>` | Override the agent command for this session only. Must be a known agent integration: `claude`, `copilot`, `gemini`, `codex`. |
 | `--no-container` | Disable container isolation for this session. The agent runs directly in the tmux pane. |
 
+`am attach` accepts one flag of its own, overriding `[attach].resume` for a single invocation:
+
+| Flag | Description |
+|---|---|
+| `--fresh` | Skip resuming the previous conversation; relaunch the agent fresh regardless of `[attach].resume`. |
+
 ---
 
 ## Settings reference
@@ -295,10 +301,22 @@ an image, and an unchanged config skips the build entirely.
 
 **Lifecycle hooks.** `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, and
 `postStartCommand` run inside the container before the agent starts. Because `am` runs
-containers with `--rm`, every `am start` creates a fresh container and the create-time hooks
-run each time — the previous container's filesystem is gone, so anything they installed must
-be reinstalled. `postAttachCommand` is not run: `am attach` moves tmux focus, it does not
-attach to the container.
+containers with `--rm`, every fresh container creation runs the create-time hooks again — the
+previous container's filesystem is gone, so anything they installed must be reinstalled. This
+applies both to `am start` and to `am attach` recreating a container that was gone (see
+[`am attach`](commands.md#am-attach-slug)); attaching to a container that is already running
+does not re-run them. `postAttachCommand` is still not run in either case — `am` has no
+"exec into a live container" attach path yet, only "switch tmux focus" or "recreate the
+container from scratch."
 
 **Not yet supported.** Configs using `dockerComposeFile` are rejected with a pointer to
 `container.mode = "image"`. `userEnvProbe` and `forwardPorts` are parsed but not applied.
+
+### `[attach]`
+
+Controls whether [`am attach`](commands.md#am-attach-slug) asks a relaunched agent to resume
+its previous conversation.
+
+| Key | Type | Default | Description | Valid Values |
+|---|---|---|---|---|
+| `resume` | boolean | `true` | Whether `am attach` asks the agent to resume its previous conversation when relaunching it, instead of starting fresh. Overridden per-invocation by `am attach --fresh` | `true`, `false` |

--- a/specs/attach-restore-agent.md
+++ b/specs/attach-restore-agent.md
@@ -1,0 +1,506 @@
+# Feature: Restore the Agent on `am attach`
+
+## Feature Overview
+
+**Problem.** `am attach <slug>` only restores the tmux *window*. It never restores the
+*agent*. Today, when a session's tmux window is gone — most commonly because the machine
+rebooted, but also if a user closed the window by hand — `cmd_attach` (`src/main.rs:1362`)
+recreates the window and split, leaves both panes sitting at a bare shell, and stops. For a
+containerized session it does not even recreate the container: it prints a `Note:` telling the
+user to run `am destroy --force <slug> && am start <slug>` instead (`src/main.rs:1403-1417`).
+The worktree survives a reboot; the agent's working context does not come back with it.
+
+Root cause, confirmed in the codebase (see `src/main.rs`, `src/session.rs`):
+
+1. `session::Session` never records which agent a session launched. `cmd_start` computes
+   `effective_agent` (`src/main.rs:668`) and uses it to `send_keys` the agent into the pane or
+   exec the container command, but never writes it into the `Session` it persists
+   (`src/main.rs:790-811`). There is nothing on disk for `am attach` to restart even in
+   principle.
+2. `cmd_attach`'s window-recreate branch passes `None` as the split's command argument
+   (`src/main.rs:1394`), unlike `cmd_start`'s equivalent split (`src/main.rs:761-768`), which
+   passes `container_shell_cmd`. The container branch explicitly punts with a `Note:` instead
+   of rebuilding anything.
+
+**User value.** A user whose machine reboots (or who closes an `am` tmux window by accident)
+gets back to exactly where they left off with a single `am attach <slug>` — window, pane
+layout, container (if any), and the agent process itself, ideally picking up its previous
+conversation rather than starting cold.
+
+**Success criteria.**
+- `am attach <slug>` on a session whose tmux window and agent process are both gone (the
+  reboot case) recreates the window/split *and* relaunches the recorded agent, by default
+  asking it to resume its previous conversation.
+- This works for both host-path and containerized sessions.
+- Attaching to a session that is still fully alive (window present, agent still running in
+  its pane) remains an instant no-op — no relaunch, no extra container/credential work.
+- Session records written before this feature (no `agent` field) degrade gracefully per
+  [OQ-1](#oq-1-fallback-agent-for-pre-existing-session-records) rather than erroring or being
+  silently ignored.
+- `cargo test` and `cargo clippy --all-targets -- -D warnings` pass, with cucumber coverage
+  for every flow in the Use-Cases section.
+
+## Assumptions
+
+- **A1.** "Resume the previous conversation" means resuming the underlying agent CLI's own
+  session/conversation state (e.g. its chat history), not anything `am` itself persists —
+  `am` only ever forwards a CLI flag; it has no visibility into agent conversation state.
+- **A2.** The container-recreate path re-runs the same preflight `am start` runs today
+  (runtime detection, credential validation, devcontainer image build-or-reuse) — an attach
+  that has to rebuild a container is allowed to be as slow as `am start`, since that only
+  happens when the container is actually gone. The already-attached fast path stays cheap.
+- **A3.** `am attach`'s window-recreate step is not wrapped in a rollback guard the way
+  `WorktreeGuard` protects `am start`'s worktree creation (`src/main.rs:718`). If the agent
+  relaunch or container recreate fails *after* the window/split already exist, the user is
+  left with an opened window and a clear error — the same "partially succeeded, retry or use
+  `am run`" state `am attach` already tolerates today. This is judged acceptable because,
+  unlike a worktree, a tmux window is cheap to redo and carries no data.
+- **A4.** Two concurrent `am attach <slug>` calls for the same session (e.g. two terminals
+  racing right after a reboot) can both decide the window is missing and both try to
+  recreate it/the container. This race already exists in `cmd_attach` today and is not
+  introduced by this feature; `lock_global_sessions()` only serializes the session-record
+  write, not the tmux/container side effects. Out of scope to fix here — noted under Edge
+  Cases, not blocking.
+- **A5.** `am run <slug> <agent>` remains the dedicated "launch a specific agent into a
+  session" primitive. This feature does not add an `--agent` override flag to `am attach` —
+  when no agent can be determined (see OQ-1), the user is pointed at `am run` instead of
+  `am attach` growing a second way to say the same thing.
+
+## Open Questions
+
+Each has a recommended default; ship the default unless the user overrides it.
+
+### OQ-1: Fallback agent for pre-existing session records
+
+A session written before this ships has no `agent` field (defaults to `None` via serde). What
+does `am attach` do for it?
+
+**Recommendation:** fall back to the current `cfg.agent` from config, mirroring `cmd_start`'s
+own precedence (`--agent` flag > `cfg.agent`) minus the flag, since attach has no `--agent`
+flag (A5). If `cfg.agent` is also `None`, behave exactly as today: open the window/pane with
+nothing launched, and add a one-line `Note:` pointing at `am run <slug> <agent>`. The first
+time this fallback fires for a record, write the resolved agent back onto the session (`s.agent
+= Some(...)`) so subsequent attaches use the recorded value instead of re-deriving it from
+config, which may have changed since.
+
+### OQ-2: Containerized path — recreate the container, or keep punting?
+
+**Recommendation:** recreate it. Reuse the same planning logic `cmd_start` already has
+(`plan_container`/`plan_image`/`plan_devcontainer`, `src/main.rs:946` onward) via a shared
+helper callable from both `cmd_start` and `cmd_attach`, feeding it data recovered from the
+`Session` record (`SessionContainer.runtime/image/mode/config_path/config_hash/remote_user`,
+`Session.auto`, and the newly-recorded `Session.agent`) plus a freshly loaded `Config`. Call
+`container::remove_if_exists` for the recorded container name first, exactly as `cmd_start`
+does for a leftover container, then pass the rebuilt run command into `split_window`'s
+`container_shell_cmd` argument instead of `None`.
+
+*Trade-off against keeping today's `Note:`:* recreating is real preflight work — credential
+validation can fail (expired token, revoked login), and a devcontainer whose image was pruned
+rebuilds from scratch. That is strictly more that can go wrong on attach than today's "print a
+hint and stop." The alternative (keep punting) is simpler and never surprises the user with a
+slow attach, but leaves the exact problem the user reported unsolved for containerized
+sessions — and `auto` mode requires a container, so a meaningful fraction of real sessions are
+containerized. Recommend recreating; if the user disagrees, the fallback is to ship OQ-2 as
+"host path only" for this PRD and keep today's `Note:` unchanged for containers.
+
+### OQ-3: Per-agent resume invocation
+
+**Not verified — do not assume.** `am` currently has no resume/continue logic anywhere, and
+the four `KnownAgent` CLIs (`src/container.rs:39`) are not guaranteed to (a) support resuming
+a previous conversation at all, or (b) use a comparable flag if they do. The team-lead's
+instruction going in was explicit: treat this as a research spike, not a known fact.
+
+**Recommendation:** the backend-engineer verifies each CLI's actual resume support and flag
+(via `--help`/docs) before wiring `--fresh`/`[attach].resume` to anything, and builds a small
+per-`KnownAgent` table, e.g. `agent_resume_flags(agent: KnownAgent) -> Option<Vec<String>>`
+returning `None` for an agent confirmed to have no resume capability. Where `None`, `am`
+silently falls back to a fresh launch — never errors just because resume isn't supported.
+Land the plumbing (the `resume: bool` parameter threaded through `agent_command`, the config
+key, the `--fresh` flag) in the same change, since none of it depends on the verified flags
+being correct on day one, but do not merge unverified flag guesses.
+
+### OQ-4: Default-on, opt-in flag, or config-driven?
+
+**Recommendation:** default-on, with a per-invocation escape hatch and a config override —
+not mutually exclusive:
+- New `[attach]` config section, `resume: bool`, default `true`.
+- New `am attach --fresh` flag forces a new conversation for this one invocation regardless
+  of config.
+- No flag to force resume when config has `resume = false` is needed in this PRD — a user who
+  wants resume-by-default just leaves the default alone.
+
+This directly satisfies the "bonus" ask (resume by default, no extra typing) while giving
+users who don't want it — or who hit a flaky per-agent resume implementation — a way out
+without editing config.
+
+### OQ-5: No prior conversation to resume
+
+**Recommendation:** `am` does not special-case this. The resume flag (once verified per OQ-3)
+is passed to the agent CLI exactly as it would be by a human typing it directly; whatever that
+CLI does when there is nothing to resume (start fresh, print a message, etc.) is what happens.
+`am` cannot observe or react to the agent's exit status here — the agent is launched via
+`tmux send_keys` into a live pane, fire-and-forget, exactly like `cmd_run` and `cmd_start`
+already do today. This is a pre-existing constraint of the send-keys launch mechanism, not a
+new gap this feature introduces.
+
+### OQ-6: Detecting an already-running agent (avoid double-launch)
+
+**Recommendation:** yes, required, and it doubles as the mechanism for
+[UC-4](#uc-4-attach-to-a-live-session-whose-agent-exited). Add
+`tmux::pane_current_command(pane_target: &str) -> Result<String>` (new function, wraps `tmux
+display-message -p -t <target> '#{pane_current_command}'`). On the "window already exists"
+fast path, query the agent pane's current foreground process before doing anything else:
+- Container sessions: compare against the container runtime binary name already on the
+  record (`SessionContainer.runtime`, e.g. `"podman"`/`"docker"`) — while the container is up,
+  that's the pane's foreground process regardless of what's running inside it; if the agent
+  process inside the container exits, the container exits too (it's the container's PID 1),
+  and the pane reverts to a shell. No new per-agent process-name table needed for this case.
+- Host sessions: compare against the recorded agent name. Some agent CLIs run under an
+  interpreter shim (`node`, `python`, …) rather than a process literally named e.g. `claude`,
+  so an exact-name match can false-negative. **Bias safe:** on any ambiguity (unrecognized
+  process name, lookup failure, pane target gone), treat it as "still running, do nothing" —
+  a missed relaunch is a minor inconvenience the user can fix with `am run`; an unwanted
+  relaunch on top of a live agent is much worse (interrupts a working session, possibly loses
+  in-flight state). Only relaunch when the pane is confidently idle at a shell prompt.
+
+## Use-Cases
+
+### UC-1: Post-reboot recovery — host (non-container) session
+
+**Actor:** developer whose machine rebooted; tmux and the agent process are gone, the git
+worktree and session record survive.
+
+**Preconditions:** a `Session` record exists for `<slug>` with `container: None`;
+`session.agent` is `Some("claude")` (or resolved via OQ-1); the developer is inside a live
+tmux server (freshly started since the reboot).
+
+**Main flow:**
+1. `am attach <slug>`.
+2. `tmux::select_window` fails (window doesn't exist).
+3. `am` creates the window and split exactly as today (`create_window` + `split_window`).
+4. `am` resolves the launch command for `session.agent`, including the resume flag unless
+   `--fresh` was passed or `[attach].resume = false`.
+5. `am` sends that command into the new agent pane via `tmux::send_keys`.
+6. `am` selects the shell pane (unchanged from today) and updates the session record's tmux
+   fields (unchanged from today).
+7. Prints e.g. `Opened new window for session '<slug>' and relaunched 'claude' (resuming).`
+
+**Postconditions:** window, split, and agent process all restored; agent pane shows the agent
+attempting to resume its last conversation in the worktree directory.
+
+**Business rules:** the launch command is built the same way `cmd_start`'s host path builds
+it (`send_keys(&pane, agent)`), with the resume flag appended per OQ-3/OQ-4.
+
+### UC-2: Post-reboot recovery — containerized session
+
+**Actor:** same as UC-1, but the session was started with a container (image or devcontainer
+mode; `auto` or not).
+
+**Preconditions:** `Session.container` is `Some(SessionContainer { .. })` with enough
+recorded (`runtime`, `image`, `mode`, `config_path`, `config_hash`, `remote_user`,
+`container_name`) to rebuild the run command; `Session.agent` is known (recorded or OQ-1
+fallback).
+
+**Main flow:**
+1. `am attach <slug>`.
+2. `tmux::select_window` fails.
+3. `am` creates the window and split (unchanged).
+4. `am` calls `container::remove_if_exists` for the recorded container name (defensive
+   cleanup, mirroring `cmd_start`).
+5. `am` rebuilds the container run command via the shared container-plan helper (OQ-2),
+   including the resume-aware agent invocation as the container's command.
+   - Devcontainer mode: if the image for the current config hash already exists locally, it
+     is reused (no rebuild); if not, it is built, exactly as `am start` would.
+6. `am` passes the rebuilt command into `split_window`'s `container_shell_cmd` argument
+   (instead of `None`), so the split execs straight into the running container like
+   `cmd_start`'s tmux path does.
+7. Prints e.g. `Opened new window for session '<slug>' and restarted the container.`
+
+**Alternative flow — image/build unavailable:** if `plan_container` fails (runtime not
+running, credentials expired, devcontainer config deleted from the worktree since it was
+built, etc.), `am` reports that error clearly. The window/split from step 3 already exist
+(A3) — the user gets a clear failure message and can retry `am attach`, fix the underlying
+problem (e.g. `podman machine start`, re-auth), or fall back to
+`am destroy --force <slug> && am start <slug>` as before.
+
+**Postconditions:** container, window, split, and agent all restored, or a clear actionable
+error if any preflight step fails.
+
+**Business rules:** never skip credential/runtime preflight just because this is "only" an
+attach — the container is genuinely gone and must be validated exactly as `am start` would.
+
+### UC-3: Attach to a still-live session (fast no-op path)
+
+**Actor:** developer who already has the session's tmux window open (in this or another
+client) and wants to jump back to it.
+
+**Preconditions:** `tmux::select_window` succeeds; the agent pane's foreground process is
+confidently the running agent (host) or the recorded container runtime (container).
+
+**Main flow:**
+1. `am attach <slug>`.
+2. `tmux::select_window` succeeds.
+3. `am` queries `pane_current_command(agent_pane)` and confirms the agent/container is
+   running (OQ-6).
+4. `am` prints `Attached to session '<slug>'.` — unchanged from today.
+
+**Postconditions:** no relaunch, no container work, no extra latency beyond the one tmux
+query added in step 3. This must stay the cheap, common-case path.
+
+### UC-4: Attach to a live session whose agent exited
+
+**Actor:** developer whose tmux window is still open, but the agent process inside the agent
+pane crashed, was killed, or exited normally (e.g. `/exit`), leaving a bare shell.
+
+**Preconditions:** `tmux::select_window` succeeds; `pane_current_command(agent_pane)` returns
+a plain shell rather than the agent/container process.
+
+**Main flow:**
+1. `am attach <slug>`.
+2. `tmux::select_window` succeeds.
+3. `pane_current_command` shows the pane is idle.
+4. `am` relaunches the recorded agent into the agent pane (resume-aware, same as UC-1 step
+   4-5) — for a container session, only if the container itself is still up (otherwise this
+   degenerates into UC-2, since a container's foreground exit ends the container).
+5. Prints a message distinct from the plain no-op, e.g. `Attached to session '<slug>'; agent
+   had exited — relaunched 'claude' (resuming).`
+
+**Postconditions:** agent process restored in an otherwise-untouched window.
+
+**Business rule:** relaunch only fires on a confident "not running" read (OQ-6); any
+ambiguity defaults to UC-3's no-op instead.
+
+### UC-5: Attach to a legacy session record (no agent ever recorded)
+
+**Actor:** developer with a session created by an `am` build that predates this feature.
+
+**Preconditions:** `Session.agent` is `None` (missing key in the on-disk JSON, defaulted by
+serde).
+
+**Main flow (window missing, `cfg.agent` set):** resolves per OQ-1 — falls back to
+`cfg.agent`, proceeds as UC-1/UC-2, and persists the resolved agent onto the record.
+
+**Alternative flow (window missing, `cfg.agent` also unset):** window/split created as today;
+no agent to launch; prints today's message plus a new `Note:` — `am attach` does not know
+which agent to launch — run 'am run <slug> <agent>'`.
+
+**Postconditions:** never errors solely because the field is missing; degrades to the best
+information available.
+
+### UC-6: Force a fresh conversation
+
+**Actor:** developer who wants a clean agent conversation instead of resuming (e.g. the last
+conversation is irrelevant to what they're about to do).
+
+**Main flow:** `am attach <slug> --fresh` — identical to UC-1/UC-2/UC-4's relaunch flows,
+except the resume flag is omitted regardless of `[attach].resume`.
+
+## Data Model
+
+### `Session` (`src/session.rs:104`)
+
+Add one field:
+
+```rust
+pub struct Session {
+    // ...existing fields...
+    /// The agent last launched into this session's agent pane (e.g. "claude"). Used by
+    /// `am attach` to relaunch the agent after a reboot or a killed window. `None` for
+    /// records written before this field existed, or for sessions started with no agent.
+    #[serde(default)]
+    pub agent: Option<String>,
+}
+```
+
+- **Constraint:** free-form string, not `KnownAgent` — mirrors `cfg.agent: Option<String>`
+  and the `--agent` flag, which both accept arbitrary strings validated lazily via
+  `KnownAgent::parse` only where a `KnownAgent` is actually needed (auth preflight, resume
+  flag lookup). An unrecognized string degrades to "launch it as a bare command, no
+  resume/auto flags" rather than erroring, matching existing `agent_command` behavior when
+  `KnownAgent::parse` fails at `cmd_start` time — note: `cmd_start` currently *does*
+  `.transpose()?` on `KnownAgent::parse`, i.e. an unknown `--agent` value already hard-errors
+  before any session is created, so a `cmd_start`-originated `Session.agent` is always a valid
+  `KnownAgent` string. `cmd_run`'s `agent: String` CLI argument has **no such validator**
+  (only `slug` has a `value_parser` in `src/cli.rs`), and `cmd_run` persists it onto
+  `Session.agent` verbatim on success — so `am run <slug> some-typo` is an ordinary way to put
+  an unparseable value on disk. `am attach` still `KnownAgent::parse`s it, but a parse failure
+  there is an expected, reachable case reached via `cmd_run`, not a "should not happen"
+  invariant — treat it as "degrade to no-resume-flag launch," full stop, not as a defensive
+  fallback for something that can't occur.
+- **Required for:** `cmd_start` (write), `cmd_run` (write — see Backend task list), `cmd_attach`
+  (read + conditional write on OQ-1 fallback).
+- **Backward compatibility:** `#[serde(default)]` — existing `sessions.json` records with no
+  `agent` key deserialize as `None`; add a unit test alongside the existing
+  `legacy_records_without_repo_root_migrate_correctly` test confirming this.
+
+### `Config` (`src/config.rs:208`)
+
+Add a new section:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttachConfig {
+    /// Whether `am attach` asks the agent to resume its previous conversation
+    /// when relaunching it, instead of starting fresh. Overridden per-invocation
+    /// by `am attach --fresh`.
+    #[serde(default = "default_true")]
+    pub resume: bool,
+}
+
+impl Default for AttachConfig {
+    fn default() -> Self {
+        Self { resume: true }
+    }
+}
+```
+
+with `pub attach: AttachConfig` added to `Config`, `#[serde(default)]`, and included in
+`Config::default()` and the `am generate-config` template output (`cmd_generate_config`).
+
+No new fields on `SessionContainer` — everything needed to rebuild a container run command
+(OQ-2) is already recorded there.
+
+## API Design
+
+`am` is a CLI, not a network service; "API" here is the command/flag/config surface.
+
+### `am attach <slug> [--fresh]`
+
+| | |
+|---|---|
+| Auth | none (local CLI) |
+| Preconditions | inside a repo `am` recognizes; inside a live tmux session (`AmError::NotInTmux` if not, unchanged); `<slug>` exists in the current repo's sessions (`AmError::SlugNotFound` if not, unchanged) |
+| New flag | `--fresh` (bool, default `false`) — skip resuming; launch/relaunch with a fresh conversation regardless of `[attach].resume` |
+| Success output | one of four messages depending on flow (UC-3 no-op / UC-1,4 relaunch / UC-2 container recreate / UC-5 no-agent-known), see each use-case |
+| Error cases | `NotInTmux`, `SlugNotFound` (unchanged); new: container/credential preflight failure surfaces the underlying error with context (UC-2 alternative flow) — window/split already created (A3) |
+
+### `am run <slug> <agent>` (existing, extended)
+
+No new flags. Behavior change: on success, also updates `session.agent = Some(agent)` and
+persists via `session::update_session_global`, so a subsequent `am attach` relaunches whatever
+was actually run last, not stale data.
+
+### Config: `[attach]` section
+
+```toml
+[attach]
+resume = true   # am attach asks the agent to resume its previous conversation by default
+```
+
+Documented in `docs/reference/configuration.md`, included in `am generate-config` output with
+its default and a one-line comment, same pattern as every other section there.
+
+## Implementation Tasks
+
+### backend-engineer
+
+- [ ] Add `Session.agent: Option<String>` (`src/session.rs`), `#[serde(default)]`; update
+      `make_session`/`make_session_for_repo` test helpers; add a roundtrip test with `agent`
+      set and a legacy-record test confirming a missing `agent` key loads as `None`.
+- [ ] Populate `new_session.agent = effective_agent.clone()` in `cmd_start`
+      (`src/main.rs:790`).
+- [ ] Update `cmd_run` (`src/main.rs:1426`) to set `s.agent = Some(agent.to_string())` and
+      call `session::update_session_global` after a successful `send_keys`.
+- [ ] Add `tmux::pane_current_command(pane_target: &str) -> Result<String>`
+      (`src/tmux.rs`), wrapping `tmux display-message -p -t <target> '#{pane_current_command}'`;
+      extend the `AM_TMUX_BIN` mock protocol and add unit/mocked coverage.
+- [ ] Extract `cmd_start`'s container-planning block (runtime detection, credential
+      preflight, `plan_container` call, leftover-container cleanup) into a helper reusable
+      from both `cmd_start` and `cmd_attach`, parameterized so `cmd_attach` can feed it data
+      recovered from a `Session` record instead of fresh CLI flags.
+- [ ] **Spike (blocking, see OQ-3):** verify, per `KnownAgent` variant, whether the CLI
+      supports resuming a previous conversation and what flag(s) that requires. Encode the
+      result as `agent_resume_flags(agent: KnownAgent) -> Option<Vec<String>>`, returning
+      `None` for any agent confirmed not to support it.
+- [ ] Extend `agent_command` (`src/main.rs:1158`) — or add a sibling — to take a `resume:
+      bool` and append `agent_resume_flags(agent)` when `Some` and `resume` is true.
+- [ ] Add `AttachConfig`/`Config.attach` (`src/config.rs`) per Data Model; wire into
+      `Config::default()` and `cmd_generate_config`'s template output.
+- [ ] Add `--fresh` flag to `Commands::Attach` (`src/cli.rs`).
+- [ ] Rewrite `cmd_attach` (`src/main.rs:1362`) per the flows in UC-1 through UC-6: fast-path
+      `pane_current_command` check (OQ-6) with the "ambiguous → no-op" safety bias; OQ-1
+      fallback-and-persist for `Session.agent == None`; host relaunch; container
+      recreate-via-shared-helper (retiring today's `Note:`/manual-restart text for the case
+      it now handles automatically — keep an error-path message pointing at
+      `am destroy --force && am start` as the manual fallback when preflight fails, per A3).
+- [ ] `cargo test` and `cargo clippy --all-targets -- -D warnings` clean.
+
+### integration-tester
+
+- [ ] New `tests/attach_restore_agent.feature` covering, with `AM_TMUX_BIN` /
+      `AM_PODMAN_BIN`/`AM_DOCKER_BIN` mocks:
+  - UC-1: window missing, host session, agent relaunched with resume flag by default.
+  - UC-6: same, with `--fresh` — assert the resume flag is absent (per CLAUDE.md's Gherkin
+    guidance: verify the *literal* absence via a dedicated Rust step or a single-quoted
+    string if the expected text needs a `"`; do not rely on a `{string}` capture around any
+    text containing a backslash escape).
+  - UC-2: window missing, containerized session — assert the mocked container runtime binary
+    records a `run` invocation with the expected image/mounts, replacing the old
+    Note-only assertion.
+  - UC-2 alternative: mocked runtime/credential failure — assert a clear error and that no
+    crash/panic occurs; window was still created.
+  - UC-3: window present, agent pane reports the agent/container running — assert no
+    `send-keys` or container `run` call happens, message unchanged from today.
+  - UC-4: window present, agent pane reports a bare shell — assert relaunch happens with a
+    message distinct from UC-3's.
+  - UC-5: legacy record, no `agent` field, `cfg.agent` unset — today's message plus the new
+    `Note:` pointing at `am run`.
+  - UC-5 fallback: legacy record, no `agent` field, `cfg.agent` set — relaunches with the
+    config's agent and persists it onto the record (assert via a follow-up `am list`/session
+    read, not just stdout).
+  - Regression: `am run <slug> <agent>` followed by `am attach` (window destroyed and
+    recreated in between) relaunches the agent from `am run`, not whatever `cmd_start`
+    originally recorded.
+- [ ] Re-run full existing suite (`start.feature`, `tmux.feature`, `container.feature`,
+      `destroy.feature`, `full_flow.feature`) to confirm no regressions to `am start`'s
+      shared container-planning path after the extraction.
+
+### code-reviewer
+
+- [ ] Confirm no unverified per-agent resume flags were merged (OQ-3 spike must show its
+      work — cite what was checked per agent, not just "guessed").
+- [ ] Confirm the OQ-6 detection defaults to "do nothing" on any ambiguous
+      `pane_current_command` read, never to "assume idle and relaunch."
+- [ ] Confirm the shared container-planning extraction didn't change `cmd_start`'s existing
+      behavior (same preflight order, same error messages) — a silent behavior drift here
+      would be a `cmd_start` regression hiding inside an `am attach` PR.
+- [ ] Confirm `Session.agent` and `AttachConfig` both round-trip through legacy records/config
+      files with sensible defaults (no crash, no silent data loss).
+
+### documentation-writer
+
+- [ ] `docs/reference/commands.md` (`am attach` section, `:395-430`): rewrite to describe the
+      relaunch/resume/container-recreate behavior, the `--fresh` flag, and the four distinct
+      output messages; retire or reframe the current `Note:`/"restart cleanly" guidance as a
+      manual fallback for when automatic recreate fails (A3), not the primary path.
+- [ ] `docs/reference/configuration.md`: document the new `[attach]` section and `resume` key.
+- [ ] `BACKLOG.md`: mark the attach-agent-restart gap resolved; add a one-line clarification
+      next to the existing `postAttachCommand` entry (`:417-419`) that container recreation
+      via this feature reruns create-time lifecycle hooks as needed (via `lifecycle_done`,
+      unchanged) but is not the same as attaching to a live container — that follow-up stays
+      open.
+
+## Edge Cases & Considerations
+
+- **Security:** no new attack surface — credential validation on the container-recreate path
+  reuses `container::validate_agent_credentials`/`preflight_agent_auth`, exactly as `am
+  start` already does. No new secrets are read, stored, or transmitted.
+- **Performance:** UC-3's fast path adds exactly one tmux query
+  (`pane_current_command`) — negligible. UC-2's container recreate is intentionally as slow
+  as `am start`'s container path (image build if needed); this only triggers when the
+  container is actually gone, so it doesn't regress the common case.
+- **UX:** four distinct outcome messages (no-op / relaunched / container recreated /
+  no-agent-known) so a user can tell at a glance what `am attach` actually did, especially
+  the first time it silently would have "worked" by doing nothing under the old behavior.
+- **Race conditions:** concurrent `am attach` for the same slug (A4) — pre-existing gap, not
+  newly introduced, not fixed by this PRD; noted for a future hardening pass.
+- **Agent CLI variability:** `am` cannot observe whether a resumed conversation actually
+  resumed anything meaningful (OQ-5) — it is fire-and-forget via `send_keys`, identical to
+  every other agent-launch path `am` already has.
+- **`postAttachCommand` is still not implemented** (tracked separately in `BACKLOG.md`).
+  Recreating a container here is not the same as exec-attaching into a live one; this feature
+  does not close that gap, only the "container is actually gone" gap.
+- **Process-name matching fragility (OQ-6, host path):** some agent CLIs run under a generic
+  interpreter shim, so `pane_current_command` may not literally equal the agent name. Bias
+  toward false negatives (no relaunch) over false positives (relaunch over a live agent) —
+  see OQ-6's recommendation.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,10 +77,13 @@ pub enum Commands {
         all: bool,
     },
 
-    /// Attach tmux focus to an existing session
+    /// Attach tmux focus to an existing session, restoring the agent if it isn't running
     Attach {
         #[arg(value_parser = validate_slug)]
         slug: String,
+        /// Skip resuming the previous conversation; launch/relaunch fresh
+        #[arg(long)]
+        fresh: bool,
     },
 
     /// Launch an agent in an existing session's agent pane
@@ -241,5 +244,26 @@ mod tests {
     #[test]
     fn init_still_parses_with_no_arguments() {
         assert!(matches!(parse(&["am", "init"]), Commands::Init));
+    }
+
+    // ── am attach ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn attach_defaults_to_no_fresh() {
+        match parse(&["am", "attach", "feat"]) {
+            Commands::Attach { slug, fresh } => {
+                assert_eq!(slug, "feat");
+                assert!(!fresh);
+            }
+            _ => panic!("expected Attach"),
+        }
+    }
+
+    #[test]
+    fn attach_accepts_fresh_flag() {
+        match parse(&["am", "attach", "feat", "--fresh"]) {
+            Commands::Attach { fresh, .. } => assert!(fresh),
+            _ => panic!("expected Attach"),
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -204,6 +204,26 @@ impl Default for DevcontainerConfig {
     }
 }
 
+/// Settings for `am attach`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttachConfig {
+    /// Whether `am attach` asks the agent to resume its previous conversation
+    /// when relaunching it, instead of starting fresh. Overridden per-invocation
+    /// by `am attach --fresh`.
+    #[serde(default = "default_true")]
+    pub resume: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for AttachConfig {
+    fn default() -> Self {
+        Self { resume: true }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub agent: Option<String>,
@@ -212,6 +232,8 @@ pub struct Config {
     pub tmux: TmuxConfig,
     pub container: ContainerConfig,
     pub devcontainer: DevcontainerConfig,
+    #[serde(default)]
+    pub attach: AttachConfig,
     /// Keys found in the config files that `am` does not recognise. Not a config value
     /// itself, so it never round-trips through a config file.
     #[serde(skip)]
@@ -256,6 +278,7 @@ impl Default for Config {
             tmux: TmuxConfig::default(),
             container: ContainerConfig::default(),
             devcontainer: DevcontainerConfig::default(),
+            attach: AttachConfig::default(),
             unknown_keys: Vec::new(),
         }
     }
@@ -343,6 +366,13 @@ struct FileDevcontainer {
 }
 
 #[derive(Debug, Deserialize, Default)]
+struct FileAttach {
+    resume: Option<bool>,
+    #[serde(flatten)]
+    unknown: HashMap<String, toml::Value>,
+}
+
+#[derive(Debug, Deserialize, Default)]
 struct FileConfig {
     #[serde(default)]
     defaults: FileDefaults,
@@ -354,6 +384,8 @@ struct FileConfig {
     container: FileContainer,
     #[serde(default)]
     devcontainer: FileDevcontainer,
+    #[serde(default)]
+    attach: FileAttach,
     #[serde(flatten)]
     unknown: HashMap<String, toml::Value>,
 }
@@ -393,6 +425,7 @@ fn collect_unknown(file: &FileConfig, path: &Path) -> Vec<UnknownKey> {
             .keys()
             .map(|k| format!("devcontainer.{k}")),
     );
+    keys.extend(file.attach.unknown.keys().map(|k| format!("attach.{k}")));
     for (name, settings) in &file.agents {
         keys.extend(
             settings
@@ -490,6 +523,8 @@ fn apply_file_config(base: &mut Config, file: FileConfig) {
     if let Some(features) = file.devcontainer.extra_features {
         base.devcontainer.extra_features.extend(features);
     }
+
+    apply_opt(&mut base.attach.resume, file.attach.resume);
 }
 
 fn parse_config_file(path: &Path) -> Result<FileConfig> {
@@ -568,6 +603,10 @@ pub fn render_project_config_skeleton() -> &'static str {
 # agent_install = "auto"     # "feature" | "bootstrap" | "none" | "auto"
 # allow_host_commands = false # let initializeCommand run on the HOST — off by default
 # skip_lifecycle = false     # skip postCreateCommand and friends
+
+[attach]
+# resume = true    # `am attach` asks the agent to resume its previous conversation by
+                   # default when relaunching it; override per-invocation with --fresh
 "#
 }
 
@@ -656,6 +695,10 @@ skip_lifecycle = false         # skip postCreateCommand and the other in-contain
 # Extra Features to inject at build time, as id -> options JSON:
 # [devcontainer.extra_features]
 # "ghcr.io/devcontainers/features/node:1" = "{}"
+
+[attach]
+resume = true          # am attach asks the agent to resume its previous conversation by
+                       # default when relaunching it; override per-invocation with --fresh
 "#
 }
 
@@ -1318,6 +1361,63 @@ image = "myorg/am-claude:project"
                 .and_then(|a| a.image.as_deref()),
             Some("ghcr.io/dstanek/am-copilot-minimal:latest")
         );
+    }
+
+    // ── [attach] ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn attach_resume_defaults_to_true() {
+        let tmp = TempDir::new().unwrap();
+        let nonexistent = tmp.path().join("global.toml");
+        let config = load_with_global(Some(&nonexistent), None).unwrap();
+        assert!(config.attach.resume);
+    }
+
+    #[test]
+    fn attach_resume_can_be_disabled_in_project_config() {
+        let tmp = TempDir::new().unwrap();
+        let project = write_toml(tmp.path(), "project.toml", "[attach]\nresume = false\n");
+
+        let config = load_with_global(None, Some(&project)).unwrap();
+        assert!(!config.attach.resume);
+    }
+
+    #[test]
+    fn attach_section_missing_from_a_pre_existing_config_still_defaults_resume_true() {
+        // A config file written before [attach] existed has no such section at all.
+        let tmp = TempDir::new().unwrap();
+        let project = write_toml(
+            tmp.path(),
+            "project.toml",
+            "[defaults]\nagent = \"claude\"\n",
+        );
+
+        let config = load_with_global(None, Some(&project)).unwrap();
+        assert!(config.attach.resume);
+    }
+
+    #[test]
+    fn unknown_attach_key_is_collected_not_rejected() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["AM_AGENT"]);
+        std::env::remove_var("AM_AGENT");
+        let tmp = TempDir::new().unwrap();
+        let project = write_toml(tmp.path(), "project.toml", "[attach]\nresuem = true\n");
+
+        let config = load_with_global(None, Some(&project)).unwrap();
+        let keys: Vec<&str> = config
+            .unknown_keys
+            .iter()
+            .map(|u| u.key.as_str())
+            .collect();
+        assert_eq!(keys, vec!["attach.resuem"]);
+    }
+
+    #[test]
+    fn global_config_template_documents_attach_section() {
+        let template = global_config_template();
+        assert!(template.contains("[attach]"));
+        assert!(template.contains("resume = true"));
     }
 
     #[test]

--- a/src/container.rs
+++ b/src/container.rs
@@ -398,6 +398,34 @@ pub fn agent_auto_flags(agent: KnownAgent) -> Vec<String> {
     }
 }
 
+/// The flags needed to ask an agent CLI to resume its previous conversation, or `None` for
+/// an agent confirmed not to support that. `am attach` appends these (OQ-3/OQ-4) instead of
+/// launching a fresh conversation, unless `--fresh` or `[attach].resume = false` says
+/// otherwise. `None` must never be treated as an error — it just means a fresh launch, same
+/// as today's behavior.
+///
+/// Every entry here was checked against the CLI's own `--help` output (not assumed) as of
+/// this writing:
+/// - `claude --help`: `-c, --continue` — "Continue the most recent conversation in the
+///   current directory" (run locally; the Claude Code CLI is present in this environment).
+/// - `npx @github/copilot --help`: `--continue` — "Resume the most recent session".
+/// - `npx @google/gemini-cli --help`: `-r, --resume <value>` — "Resume a previous session.
+///   Use \"latest\" for most recent or index number".
+/// - `npx @openai/codex resume --help`: `resume` is a subcommand, not a flag on the base
+///   invocation; `--last` — "Continue the most recent session without showing the picker" —
+///   and that selection is itself scoped to the current working directory by default (its
+///   sibling `--all` flag is documented as "disables cwd filtering").
+pub fn agent_resume_flags(agent: KnownAgent) -> Option<Vec<String>> {
+    match agent {
+        KnownAgent::Claude => Some(vec!["--continue".to_string()]),
+        KnownAgent::Copilot => Some(vec!["--continue".to_string()]),
+        KnownAgent::Gemini => Some(vec!["--resume".to_string(), "latest".to_string()]),
+        // A subcommand, not a flag — `agent_command` puts this right after the binary
+        // name, giving `codex resume --last`.
+        KnownAgent::Codex => Some(vec!["resume".to_string(), "--last".to_string()]),
+    }
+}
+
 /// Runs `gh auth token` and returns the token string.
 fn get_gh_token() -> Result<String> {
     let gh = find_bin("gh", "AM_GH_BIN").ok_or_else(|| {
@@ -960,6 +988,54 @@ mod tests {
         assert!(agent_auto_flags(KnownAgent::Codex).is_empty());
         assert!(agent_auto_flags(KnownAgent::Copilot).is_empty());
         assert!(agent_auto_flags(KnownAgent::Gemini).is_empty());
+    }
+
+    // ── agent_resume_flags (OQ-3) ─────────────────────────────────────────────
+
+    #[test]
+    fn agent_resume_flags_claude_uses_continue() {
+        assert_eq!(
+            agent_resume_flags(KnownAgent::Claude),
+            Some(vec!["--continue".to_string()])
+        );
+    }
+
+    #[test]
+    fn agent_resume_flags_copilot_uses_continue() {
+        assert_eq!(
+            agent_resume_flags(KnownAgent::Copilot),
+            Some(vec!["--continue".to_string()])
+        );
+    }
+
+    #[test]
+    fn agent_resume_flags_gemini_uses_resume_latest() {
+        assert_eq!(
+            agent_resume_flags(KnownAgent::Gemini),
+            Some(vec!["--resume".to_string(), "latest".to_string()])
+        );
+    }
+
+    #[test]
+    fn agent_resume_flags_codex_uses_resume_subcommand() {
+        assert_eq!(
+            agent_resume_flags(KnownAgent::Codex),
+            Some(vec!["resume".to_string(), "--last".to_string()])
+        );
+    }
+
+    #[test]
+    fn agent_resume_flags_never_returns_none_by_accident() {
+        // Every known agent was verified to support resuming (see agent_resume_flags's
+        // doc comment); pin that none of them silently regress to "unsupported".
+        for agent in [
+            KnownAgent::Claude,
+            KnownAgent::Copilot,
+            KnownAgent::Gemini,
+            KnownAgent::Codex,
+        ] {
+            assert!(agent_resume_flags(agent).is_some(), "{agent} should support resume");
+        }
     }
 
     fn fake_runtime(kind: RuntimeKind, dir: &Path) -> ContainerRuntime {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             rebuild,
         } => cmd_start(&slug, agent.as_deref(), no_container, auto, rebuild),
         Commands::List { all } => cmd_list(all),
-        Commands::Attach { slug } => cmd_attach(&slug),
+        Commands::Attach { slug, fresh } => cmd_attach(&slug, fresh),
         Commands::Run { slug, agent } => cmd_run(&slug, &agent),
         Commands::Destroy { slug, force } => cmd_destroy(&slug, force, &msgs),
         Commands::Doctor => cmd_doctor(None),
@@ -700,13 +700,11 @@ fn cmd_start(
     //    does, so its half of preflight happens below.
     let use_container = cfg.container.enabled && !no_container;
     let runtime = if use_container {
-        let runtime = container::detect_runtime(cfg.container.runtime.clone())?;
-        if let Some(agent) = effective_known_agent {
-            container::validate_agent_credentials(agent)?;
-        }
-        // Pre-emptively remove any leftover container from a previous run
-        container::remove_if_exists(&runtime, &container_name);
-        Some(runtime)
+        Some(plan_container_runtime(
+            &cfg,
+            effective_known_agent,
+            &container_name,
+        )?)
     } else {
         None
     };
@@ -733,6 +731,8 @@ fn cmd_start(
                 auto,
                 rebuild,
                 container_name: &container_name,
+                // A freshly started session never resumes anything.
+                resume: false,
             })?;
             (Some(plan.cmd), Some(plan.session))
         }
@@ -808,6 +808,7 @@ fn cmd_start(
             original_shell_dir: None,
         },
         container: session_container,
+        agent: effective_agent.clone(),
     };
 
     let color_enabled = color::enabled(color::Stream::Stdout);
@@ -934,11 +935,35 @@ struct ContainerPlanInput<'a> {
     auto: bool,
     rebuild: bool,
     container_name: &'a str,
+    /// Append the agent's resume flags (OQ-3/OQ-4), if it has any. `cmd_start` always
+    /// passes `false` — a fresh session has nothing to resume; `am attach`'s container
+    /// recreate path (OQ-2) passes through its own resolved resume decision.
+    resume: bool,
 }
 
 struct ContainerPlan {
     cmd: Vec<String>,
     session: session::SessionContainer,
+}
+
+/// Container runtime detection, agent credential preflight, and leftover-container
+/// cleanup — the fixed prefix of container planning, run before there is anything else to
+/// plan. Shared by `cmd_start` (fresh session) and `cmd_attach`'s container recreate path
+/// (OQ-2), extracted out of `cmd_start`'s own inline block so both run the identical
+/// preflight in the identical order; `cmd_start`'s behavior here is unchanged by the
+/// extraction.
+fn plan_container_runtime(
+    cfg: &config::Config,
+    agent: Option<container::KnownAgent>,
+    container_name: &str,
+) -> anyhow::Result<container::ContainerRuntime> {
+    let runtime = container::detect_runtime(cfg.container.runtime.clone())?;
+    if let Some(agent) = agent {
+        container::validate_agent_credentials(agent)?;
+    }
+    // Pre-emptively remove any leftover container from a previous run.
+    container::remove_if_exists(&runtime, container_name);
+    Ok(runtime)
 }
 
 /// Decide whether this session runs from an `am`-resolved image or the repo's own
@@ -956,6 +981,7 @@ fn plan_container(input: ContainerPlanInput) -> anyhow::Result<ContainerPlan> {
         auto,
         rebuild,
         container_name,
+        resume,
     } = input;
 
     // Discovery is relative to the worktree: the config is a checked-in, branch-specific
@@ -981,10 +1007,10 @@ fn plan_container(input: ContainerPlanInput) -> anyhow::Result<ContainerPlan> {
     match config_path {
         Some(path) => plan_devcontainer(
             slug, repo_root, worktree, vcs, cfg, runtime, agent, agent_name, auto, rebuild, &path,
-            container_name,
+            container_name, resume,
         ),
         None => plan_image(slug, repo_root, vcs, cfg, runtime, agent, agent_name, auto,
-            container_name),
+            container_name, resume),
     }
 }
 
@@ -1000,6 +1026,7 @@ fn plan_image(
     agent_name: Option<&str>,
     auto: bool,
     container_name: &str,
+    resume: bool,
 ) -> anyhow::Result<ContainerPlan> {
     let image = config::resolve_image(agent_name, cfg)
         .ok_or(error::AmError::ContainerImageNotConfigured)?;
@@ -1029,7 +1056,7 @@ fn plan_image(
         container_name,
         &container::DevcontainerRuntime::image_mode(),
     );
-    cmd.extend(agent_command(agent, auto));
+    cmd.extend(agent_command(agent_name, agent, auto, resume));
     Ok(ContainerPlan {
         cmd,
         session: session::SessionContainer::image_mode(
@@ -1055,6 +1082,7 @@ fn plan_devcontainer(
     rebuild: bool,
     config_path: &std::path::Path,
     container_name: &str,
+    resume: bool,
 ) -> anyhow::Result<ContainerPlan> {
     let json = devcontainer::parse_config(config_path)?;
     devcontainer::check_supported(&json)?;
@@ -1135,7 +1163,7 @@ fn plan_devcontainer(
     chain.extend(hooks);
     cmd.extend(container::compose_entrypoint_command(
         &chain,
-        &agent_command(agent, auto),
+        &agent_command(agent_name, agent, auto, resume),
     ));
 
     Ok(ContainerPlan {
@@ -1154,14 +1182,44 @@ fn plan_devcontainer(
     })
 }
 
-/// The agent invocation appended as the container command, if there is one.
-fn agent_command(agent: Option<container::KnownAgent>, auto: bool) -> Vec<String> {
-    let Some(agent) = agent else {
+/// The agent invocation appended as the container command, if there is one — or, for a
+/// host-side relaunch (`am attach`, `cmd_run`), the command line sent into the agent pane.
+///
+/// `agent_name` is the raw string to launch (`cfg.agent`, `--agent`, or a recorded
+/// `Session.agent`) and `known` is that same value already parsed to a `KnownAgent`, kept
+/// separate so an unrecognized name still launches as a bare command rather than vanishing.
+/// This is not a defensive fallback for something that "shouldn't happen": `cmd_start`
+/// validates `--agent` via `KnownAgent::parse` before any session exists, so a
+/// `cmd_start`-originated `Session.agent` is always parseable, but `cmd_run`'s `agent`
+/// argument (`src/cli.rs`) has no such validator and is persisted onto `Session.agent`
+/// verbatim on success — so `am run <slug> some-typo` is an ordinary, everyday way to reach
+/// `known: None` here, later, via `am attach`.
+fn agent_command(
+    agent_name: Option<&str>,
+    known: Option<container::KnownAgent>,
+    auto: bool,
+    resume: bool,
+) -> Vec<String> {
+    let Some(name) = agent_name else {
         return Vec::new();
     };
-    let mut cmd = vec![agent.to_string()];
-    if auto {
-        cmd.extend(container::agent_auto_flags(agent));
+    let mut cmd = vec![name.to_string()];
+    if let Some(agent) = known {
+        // Auto flags are appended before resume flags. Latent ordering constraint: if an
+        // agent ever has both a non-empty `agent_auto_flags` *and* a subcommand-shaped
+        // resume form (like Codex's `resume --last`, which must be the very first token
+        // after the binary name, not just present anywhere), appending auto flags first
+        // would produce an invalid invocation. Harmless today only because
+        // `agent_auto_flags(Codex)` is empty — revisit this ordering if that changes, or if
+        // `auto` and `resume` are ever combined for an agent with a subcommand-shaped resume.
+        if auto {
+            cmd.extend(container::agent_auto_flags(agent));
+        }
+        if resume {
+            if let Some(flags) = container::agent_resume_flags(agent) {
+                cmd.extend(flags);
+            }
+        }
     }
     cmd
 }
@@ -1359,7 +1417,367 @@ fn cmd_list_all() -> anyhow::Result<()> {
 
 // ── am attach ────────────────────────────────────────────────────────────────
 
-fn cmd_attach(slug: &str) -> anyhow::Result<()> {
+/// Whether an agent pane is confidently idle (safe to relaunch into), confidently running an
+/// agent/container, or ambiguous. See `agent_pane_status`'s doc for the safety bias.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaneStatus {
+    Running,
+    Idle,
+    Ambiguous,
+}
+
+/// Common shell process names a pane sitting at an interactive prompt reports as its
+/// foreground command. Used only to recognize "idle" — anything else is either the agent
+/// itself or unrecognized, and both are treated the same way by `agent_pane_status`.
+const SHELL_PROCESS_NAMES: &[&str] = &["sh", "bash", "zsh", "dash", "fish", "ksh", "tcsh", "csh"];
+
+/// `true` for a pane sitting at a bare interactive shell prompt.
+///
+/// A login shell's reported command sometimes keeps a leading `-` (e.g. `-bash`); stripped
+/// before comparing so both forms match the same table.
+fn is_shell_process(name: &str) -> bool {
+    SHELL_PROCESS_NAMES.contains(&name.trim_start_matches('-'))
+}
+
+/// OQ-6: decide whether `am attach`'s fast path (window already exists) should leave a
+/// session alone or relaunch into it.
+///
+/// Biased hard toward `Ambiguous`/`Running` over `Idle`: an unrecognized foreground process
+/// name, a failed tmux query, or a gone pane target are all treated the same as "still
+/// running" — a missed relaunch costs the user an `am run`, but relaunching over a live agent
+/// can interrupt real work or lose in-flight state. Only a foreground process that is
+/// recognizably a bare shell counts as confidently idle.
+///
+/// - Container sessions compare against the recorded runtime binary name
+///   (`SessionContainer.runtime`, e.g. `"podman"`) rather than the agent: while the
+///   container is up, that is the pane's foreground process regardless of what is running
+///   inside it, and the container is the container's PID 1 — if the process inside it exits,
+///   so does the container, and the pane reverts to a shell.
+/// - Host sessions compare against the recorded agent name directly. No table of interpreter
+///   shims is attempted here — an agent running under `node`/`python`/etc. simply reads as
+///   `Ambiguous`, which is the safe outcome anyway.
+fn agent_pane_status(s: &session::Session) -> PaneStatus {
+    let current = match tmux::pane_current_command(&s.tmux.agent_pane) {
+        Ok(name) => name,
+        Err(_) => return PaneStatus::Ambiguous,
+    };
+    let expected_running = match &s.container {
+        Some(container) => Some(container.runtime.as_str()),
+        None => s.agent.as_deref(),
+    };
+    match expected_running {
+        Some(expected) if current == expected => PaneStatus::Running,
+        _ if is_shell_process(&current) => PaneStatus::Idle,
+        _ => PaneStatus::Ambiguous,
+    }
+}
+
+/// Whether `resume` actually contributes a flag for `known_agent` — used only to decide the
+/// "(resuming)" wording in `am attach`'s output; the same test `agent_command` itself applies
+/// via `agent_resume_flags`.
+fn resume_will_apply(known_agent: Option<container::KnownAgent>, resume: bool) -> bool {
+    resume && known_agent.is_some_and(|a| container::agent_resume_flags(a).is_some())
+}
+
+/// What `am attach` actually launched, for building its output line — a host agent, a
+/// recreated container, or nothing (no agent could be determined; OQ-1/UC-5).
+enum AttachLaunch {
+    Agent { name: String, resumed: bool },
+    Container,
+    NoAgentKnown,
+}
+
+/// `am attach`'s output line after opening a brand-new window (UC-1/UC-2/UC-5).
+fn attach_recreate_message(slug: &str, launch: &AttachLaunch) -> String {
+    match launch {
+        AttachLaunch::NoAgentKnown => format!("Opened new window for session '{slug}'."),
+        AttachLaunch::Agent { name, resumed } => {
+            let suffix = if *resumed { " (resuming)" } else { "" };
+            format!("Opened new window for session '{slug}' and relaunched '{name}'{suffix}.")
+        }
+        AttachLaunch::Container => {
+            format!("Opened new window for session '{slug}' and restarted the container.")
+        }
+    }
+}
+
+/// `am attach`'s output line after relaunching into an already-open window whose agent pane
+/// was found idle (UC-4).
+fn attach_relaunch_message(slug: &str, launch: &AttachLaunch) -> String {
+    match launch {
+        AttachLaunch::NoAgentKnown => format!("Attached to session '{slug}'."),
+        AttachLaunch::Agent { name, resumed } => {
+            let suffix = if *resumed { " (resuming)" } else { "" };
+            format!(
+                "Attached to session '{slug}'; agent had exited — relaunched '{name}'{suffix}."
+            )
+        }
+        AttachLaunch::Container => {
+            format!("Attached to session '{slug}'; container had exited — restarted it.")
+        }
+    }
+}
+
+/// Rebuild a containerized session's run command from its persisted record plus a freshly
+/// loaded config (OQ-2) — the same preflight `cmd_start` runs, just fed from a `Session`
+/// instead of fresh CLI input. Also replaces `s.container` with the freshly resolved
+/// `SessionContainer` (mode/hash/etc. may have changed, e.g. a devcontainer image rebuilt
+/// since this session was started).
+fn attach_recreate_container_cmd(
+    repo_root: &Path,
+    vcs: &config::Vcs,
+    cfg: &config::Config,
+    slug: &str,
+    s: &mut session::Session,
+    known_agent: Option<container::KnownAgent>,
+    resume: bool,
+) -> anyhow::Result<Vec<String>> {
+    let recreate_name = s
+        .container
+        .as_ref()
+        .and_then(|c| c.container_name.clone())
+        .unwrap_or_else(|| container_name(repo_root, slug));
+
+    let runtime = plan_container_runtime(cfg, known_agent, &recreate_name)?;
+
+    let plan = plan_container(ContainerPlanInput {
+        slug,
+        repo_root,
+        worktree: &s.vcs.worktree_path,
+        vcs,
+        cfg,
+        runtime: &runtime,
+        agent: known_agent,
+        agent_name: s.agent.as_deref(),
+        auto: s.auto,
+        rebuild: false,
+        container_name: &recreate_name,
+        resume,
+    })?;
+
+    let mut session_container = plan.session;
+    session_container.container_name = Some(recreate_name);
+    s.container = Some(session_container);
+
+    Ok(plan.cmd)
+}
+
+/// UC-1/UC-2/UC-5: the session's tmux window (and, for a container session, the container
+/// itself) is gone. Recreate the window and split unconditionally first, record the new pane
+/// targets, and only then attempt to launch anything into the fresh agent pane — a launch
+/// failure must never leave the session record pointing at panes that don't exist (see below).
+///
+/// Not wrapped in a rollback guard (A3): if the container recreate fails, the window and split
+/// this function already created are left open rather than torn down — a tmux window is cheap
+/// to redo and carries no data, unlike the worktree `cmd_start` guards.
+///
+/// Split first, launch second — deliberately, not `cmd_start`'s "exec the container as the
+/// split's own command" ordering: this function cannot know the container run command until
+/// *after* running preflight (runtime detection, credential validation, image build-or-reuse),
+/// which can fail. If it split with that command as `cmd_start` does and preflight failed
+/// first, there would be no split at all — the session record would still claim pane targets
+/// that were never created, `am attach`'s window-exists fast path would then find a *missing*
+/// pane, OQ-6 would (correctly) read that as `Ambiguous`, and the user would be stuck in a
+/// silent no-op loop with no way to make progress short of `am destroy`. Splitting first with
+/// no command, persisting those pane targets, and then `send_keys`-ing the launch command in
+/// (exactly like the already-open-window path in `relaunch_into_existing_window`) means a
+/// launch failure leaves a real, addressable window+split behind, and the record already
+/// matches it.
+fn recreate_attach_window(
+    repo_root: &Path,
+    vcs: &config::Vcs,
+    cfg: &config::Config,
+    slug: &str,
+    s: &mut session::Session,
+    known_agent: Option<container::KnownAgent>,
+    resume: bool,
+) -> anyhow::Result<()> {
+    let window_id = tmux::create_window(&s.tmux.tmux_window, &s.vcs.worktree_path)
+        .map_err(|e| anyhow::anyhow!(
+            "{e}\nHint: a window named '{}' may already exist — run 'am destroy {slug}' first",
+            s.tmux.tmux_window
+        ))?;
+    let (agent_pane_idx, shell_pane_idx, split_before) = pane_layout(&cfg.tmux.agent_pane);
+    tmux::split_window(
+        &window_id,
+        &s.vcs.worktree_path,
+        &cfg.tmux.split,
+        cfg.tmux.split_percent,
+        split_before,
+        None,
+    )?;
+
+    s.tmux.tmux_window_id = Some(window_id.clone());
+    s.tmux.agent_pane = tmux::get_pane_id(&window_id, agent_pane_idx);
+    s.tmux.shell_pane = tmux::get_pane_id(&window_id, shell_pane_idx);
+    // Persist now, before attempting any launch: the window and split above already exist,
+    // so the record must reflect that even if what follows fails.
+    session::update_session_global(s.clone())?;
+
+    let launch = launch_into_agent_pane(repo_root, vcs, cfg, slug, s, known_agent, resume)?;
+    // Persist again: a container recreate replaces s.container with a freshly resolved plan
+    // (mode/hash may have changed). A host launch or the no-agent case changes nothing further,
+    // so this second write is a harmless no-op for those, kept for a single code path rather
+    // than a conditional one.
+    session::update_session_global(s.clone())?;
+
+    tmux::select_pane(&tmux::get_pane_id(&window_id, shell_pane_idx))?;
+    tmux::select_window(&window_id)?;
+
+    println!("{}", attach_recreate_message(slug, &launch));
+    print_no_agent_known_note(slug, s.agent.is_none());
+    Ok(())
+}
+
+/// UC-4: the window is still open, but `agent_pane_status` found the agent pane confidently
+/// idle. Relaunch by typing into the existing pane (`send_keys`) rather than recreating any
+/// tmux structure. For a container session an idle pane means the container itself already
+/// exited (it is the container's PID 1), so this degenerates into the same OQ-2 recreate
+/// `recreate_attach_window`'s container branch performs — just delivered via `send_keys`
+/// into the pane that is already there instead of exec'd at split time.
+fn relaunch_into_existing_window(
+    repo_root: &Path,
+    vcs: &config::Vcs,
+    cfg: &config::Config,
+    slug: &str,
+    s: &mut session::Session,
+    known_agent: Option<container::KnownAgent>,
+    resume: bool,
+) -> anyhow::Result<()> {
+    let launch = launch_into_agent_pane(repo_root, vcs, cfg, slug, s, known_agent, resume)?;
+    // A container recreate replaces s.container with a freshly resolved plan; a host
+    // relaunch or the no-agent case changes nothing further, so this is a harmless no-op
+    // write for those — kept unconditional for the same reason as
+    // `recreate_attach_window`'s second persist.
+    session::update_session_global(s.clone())?;
+
+    println!("{}", attach_relaunch_message(slug, &launch));
+    print_no_agent_known_note(slug, s.agent.is_none());
+    Ok(())
+}
+
+/// Build the launch command for this session's agent pane — a container recreate
+/// (`attach_recreate_container_cmd`) or a host agent relaunch (`agent_command`), whichever
+/// this session calls for — and `send_keys` it into `s.tmux.agent_pane`.
+///
+/// Shared by both `am attach` launch sites: a freshly split pane in `recreate_attach_window`
+/// (which persists the pane targets before calling this, so a failure here still leaves a
+/// usable, correctly-recorded window+split) and an already-open, confidently-idle pane in
+/// `relaunch_into_existing_window`. Factored out so host/container handling can't drift
+/// between the two call sites the way it did before this was one function.
+fn launch_into_agent_pane(
+    repo_root: &Path,
+    vcs: &config::Vcs,
+    cfg: &config::Config,
+    slug: &str,
+    s: &mut session::Session,
+    known_agent: Option<container::KnownAgent>,
+    resume: bool,
+) -> anyhow::Result<AttachLaunch> {
+    if s.container.is_some() {
+        let cmd = attach_recreate_container_cmd(repo_root, vcs, cfg, slug, s, known_agent, resume)?;
+        let keys = cmd.iter().map(|t| shell_quote(t)).collect::<Vec<_>>().join(" ");
+        tmux::send_keys(&s.tmux.agent_pane, &keys)?;
+        return Ok(AttachLaunch::Container);
+    }
+    match s.agent.clone() {
+        Some(name) => {
+            let cmd = agent_command(Some(&name), known_agent, false, resume);
+            let keys = cmd.iter().map(|t| shell_quote(t)).collect::<Vec<_>>().join(" ");
+            tmux::send_keys(&s.tmux.agent_pane, &keys)?;
+            Ok(AttachLaunch::Agent {
+                resumed: resume_will_apply(known_agent, resume),
+                name,
+            })
+        }
+        // No agent recorded and no `cfg.agent` to fall back to (UC-5). Reachable from both
+        // call sites — `recreate_attach_window`'s window-missing path, and
+        // `relaunch_into_existing_window`'s idle-pane path, since `agent_pane_status` reports
+        // `Idle` for a bare shell whether or not an agent is recorded (see
+        // `host_session_with_no_recorded_agent_at_a_shell_reads_as_idle_but_relaunches_nothing`).
+        None => Ok(AttachLaunch::NoAgentKnown),
+    }
+}
+
+/// The `Note:` printed after either attach path when no agent could be determined at all
+/// (UC-5) — indented as a detail line under the headline it follows, same as `am start`'s own
+/// detail lines and the old container-recreate note this replaces.
+fn print_no_agent_known_note(slug: &str, no_agent_known: bool) {
+    if no_agent_known {
+        println!(
+            "  {} am attach does not know which agent to launch — run 'am run {slug} <agent>'",
+            note_prefix()
+        );
+    }
+}
+
+fn cmd_attach(slug: &str, fresh: bool) -> anyhow::Result<()> {
+    let (repo_root, vcs) = find_repo_root()?;
+    if let Err(e) = session::migrate_sessions(&repo_root) {
+        eprintln!("{} session migration failed: {e}", warning_prefix());
+    }
+    let sessions = session::load_sessions_for_repo(&repo_root)?;
+
+    let mut s = session::find_session(&sessions, slug)
+        .ok_or_else(|| error::AmError::SlugNotFound(slug.to_string()))?
+        .clone();
+
+    if !tmux::is_in_tmux() {
+        return Err(error::AmError::NotInTmux.into());
+    }
+
+    let cfg = load_config(&repo_root)?;
+
+    // OQ-1: a record written before `Session.agent` existed falls back to `cfg.agent`,
+    // mirroring cmd_start's own `--agent` > `cfg.agent` precedence minus the flag (attach has
+    // none — A5). Persisted immediately — independent of whatever happens below — so a later
+    // attach doesn't re-derive it from config, which may have changed since.
+    if s.agent.is_none() {
+        if let Some(cfg_agent) = cfg.agent.clone() {
+            s.agent = Some(cfg_agent);
+            session::update_session_global(s.clone())?;
+        }
+    }
+    // `cmd_start` validates `--agent` via `KnownAgent::parse` before writing a session, but
+    // `cmd_run`'s `agent` argument has no such validator (see `agent_command`'s doc comment)
+    // and is persisted verbatim — so a parse failure here is an expected, reachable case
+    // (e.g. `am run <slug> some-typo`), not a "should not happen" one. Handled the same way
+    // either way: not propagated as an error, `agent_command` still launches the bare
+    // string, just without resume/auto flags.
+    let known_agent = s
+        .agent
+        .as_deref()
+        .and_then(|name| container::KnownAgent::parse(name).ok());
+    let resume = !fresh && cfg.attach.resume;
+
+    let window_target = s
+        .tmux
+        .tmux_window_id
+        .clone()
+        .unwrap_or_else(|| s.tmux.tmux_window.clone());
+
+    if tmux::select_window(&window_target).is_err() {
+        // Persists its own changes internally — see its doc comment for why that can't wait
+        // until this function returns.
+        recreate_attach_window(&repo_root, &vcs, &cfg, slug, &mut s, known_agent, resume)?;
+    } else {
+        match agent_pane_status(&s) {
+            PaneStatus::Idle => {
+                // Also persists its own changes internally.
+                relaunch_into_existing_window(&repo_root, &vcs, &cfg, slug, &mut s, known_agent, resume)?;
+            }
+            PaneStatus::Running | PaneStatus::Ambiguous => {
+                println!("Attached to session '{slug}'.");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ── am run ────────────────────────────────────────────────────────────────────
+
+fn cmd_run(slug: &str, agent: &str) -> anyhow::Result<()> {
     let (repo_root, _) = find_repo_root()?;
     if let Err(e) = session::migrate_sessions(&repo_root) {
         eprintln!("{} session migration failed: {e}", warning_prefix());
@@ -1374,71 +1792,14 @@ fn cmd_attach(slug: &str) -> anyhow::Result<()> {
         return Err(error::AmError::NotInTmux.into());
     }
 
-    let window_name = &s.tmux.tmux_window;
-    let window_target = s.tmux.tmux_window_id.as_deref().unwrap_or(window_name);
-
-    // Try to switch to an existing window; if it's not there, create it.
-    if tmux::select_window(window_target).is_err() {
-        let cfg = load_config(&repo_root)?;
-        let window_id = tmux::create_window(window_name, &s.vcs.worktree_path)
-            .map_err(|e| anyhow::anyhow!(
-                "{e}\nHint: a window named '{window_name}' may already exist — run 'am destroy {slug}' first"
-            ))?;
-        let (agent_pane_idx, shell_pane_idx, split_before) = pane_layout(&cfg.tmux.agent_pane);
-        tmux::split_window(
-            &window_id,
-            &s.vcs.worktree_path,
-            &cfg.tmux.split,
-            cfg.tmux.split_percent,
-            split_before,
-            None,
-        )?;
-        tmux::select_pane(&tmux::get_pane_id(&window_id, shell_pane_idx))?;
-        tmux::select_window(&window_id)?;
-        s.tmux.tmux_window_id = Some(window_id.clone());
-        s.tmux.agent_pane = tmux::get_pane_id(&window_id, agent_pane_idx);
-        s.tmux.shell_pane = tmux::get_pane_id(&window_id, shell_pane_idx);
-        session::update_session_global(s.clone())?;
-        println!("Opened new window for session '{slug}'.");
-        if s.container.is_some() {
-            let color_enabled = color::enabled(color::Stream::Stdout);
-            // `note_prefix()` already carries its own color; dimming this line too would
-            // nest a second color inside it, the same case `render_init_report`'s own
-            // `.gitignore` advisory line handles by keeping the prefix at its own severity
-            // and leaving only the rest of the line plain.
-            println!("  {} the container was stopped when the window closed.", note_prefix());
-            println!(
-                "{}",
-                onboarding::dim_line(
-                    &format!("To restart cleanly: am destroy --force {slug} && am start {slug}"),
-                    color_enabled
-                )
-            );
-        }
-    } else {
-        println!("Attached to session '{slug}'.");
-    }
-    Ok(())
-}
-
-// ── am run ────────────────────────────────────────────────────────────────────
-
-fn cmd_run(slug: &str, agent: &str) -> anyhow::Result<()> {
-    let (repo_root, _) = find_repo_root()?;
-    if let Err(e) = session::migrate_sessions(&repo_root) {
-        eprintln!("{} session migration failed: {e}", warning_prefix());
-    }
-    let sessions = session::load_sessions_for_repo(&repo_root)?;
-
-    let s = session::find_session(&sessions, slug)
-        .ok_or_else(|| error::AmError::SlugNotFound(slug.to_string()))?;
-
-    if !tmux::is_in_tmux() {
-        return Err(error::AmError::NotInTmux.into());
-    }
-
     tmux::send_keys(&s.tmux.agent_pane, agent)?;
     tmux::select_window(s.tmux.tmux_window_id.as_deref().unwrap_or(&s.tmux.tmux_window))?;
+
+    // Record what was actually run so a later `am attach` relaunches this, not whatever
+    // `cmd_start` originally recorded (or nothing, for a legacy record).
+    s.agent = Some(agent.to_string());
+    session::update_session_global(s)?;
+
     println!("Launched '{agent}' in session '{slug}'.");
     Ok(())
 }
@@ -2413,15 +2774,309 @@ mod tests {
 
     #[test]
     fn agent_command_is_empty_without_an_agent() {
-        assert!(agent_command(None, false).is_empty());
+        assert!(agent_command(None, None, false, false).is_empty());
     }
 
     #[test]
     fn agent_command_adds_auto_flags_only_in_auto_mode() {
-        assert_eq!(agent_command(Some(KnownAgent::Claude), false), vec!["claude"]);
         assert_eq!(
-            agent_command(Some(KnownAgent::Claude), true),
+            agent_command(Some("claude"), Some(KnownAgent::Claude), false, false),
+            vec!["claude"]
+        );
+        assert_eq!(
+            agent_command(Some("claude"), Some(KnownAgent::Claude), true, false),
             vec!["claude", "--dangerously-skip-permissions"]
+        );
+    }
+
+    #[test]
+    fn agent_command_adds_resume_flags_only_when_requested() {
+        assert_eq!(
+            agent_command(Some("claude"), Some(KnownAgent::Claude), false, false),
+            vec!["claude"]
+        );
+        assert_eq!(
+            agent_command(Some("claude"), Some(KnownAgent::Claude), false, true),
+            vec!["claude", "--continue"]
+        );
+    }
+
+    #[test]
+    fn agent_command_combines_auto_and_resume_flags() {
+        assert_eq!(
+            agent_command(Some("claude"), Some(KnownAgent::Claude), true, true),
+            vec!["claude", "--dangerously-skip-permissions", "--continue"]
+        );
+    }
+
+    #[test]
+    fn agent_command_degrades_to_a_bare_command_for_an_unrecognized_name() {
+        // Defensive path (see cmd_attach's OQ-1 handling): a raw agent name that fails
+        // KnownAgent::parse still launches, just with no auto/resume flags — never a
+        // silent no-op.
+        assert_eq!(
+            agent_command(Some("some-custom-agent"), None, true, true),
+            vec!["some-custom-agent"]
+        );
+    }
+
+    // ── cmd_attach: OQ-6 pane status ────────────────────────────────────────────
+
+    use super::{agent_pane_status, is_shell_process, PaneStatus};
+    use crate::session::{Session, SessionContainer, TmuxMetadata, VcsMetadata};
+    use std::sync::Mutex;
+
+    // Mutex to serialise all tests that set AM_TMUX_BIN / MOCK_TMUX_PANE_CMD — RUST_TEST_
+    // THREADS=1 already serialises the whole binary (see CLAUDE.md's exec-mock note), but the
+    // mutex documents the real constraint independent of that global setting.
+    static PANE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn attach_test_session(slug: &str) -> Session {
+        Session {
+            slug: slug.to_string(),
+            created_at: chrono::Utc::now(),
+            auto: false,
+            repo_root: std::path::PathBuf::new(),
+            vcs: VcsMetadata {
+                branch: format!("am/{slug}"),
+                worktree_path: std::path::PathBuf::from(format!(".am/worktrees/{slug}")),
+            },
+            tmux: TmuxMetadata {
+                tmux_window: format!("am-{slug}"),
+                tmux_window_id: None,
+                agent_pane: format!("am-{slug}.1"),
+                shell_pane: format!("am-{slug}.0"),
+                original_window_name: None,
+                original_shell_dir: None,
+            },
+            container: None,
+            agent: None,
+        }
+    }
+
+    /// Point `AM_TMUX_BIN` at a script that answers `display-message` with
+    /// `$MOCK_TMUX_PANE_CMD`, mirroring `tmux.rs`'s own test mock (`pane_current_command`'s
+    /// unit tests live there; this only needs the same protocol, not the whole harness).
+    struct MockPaneCmd {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        _tmp: tempfile::TempDir,
+    }
+
+    impl MockPaneCmd {
+        fn set(current: &str) -> Self {
+            let guard = PANE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let tmp = tempfile::TempDir::new().unwrap();
+            let script = tmp.path().join("mock_tmux");
+            std::fs::write(&script, "#!/bin/sh\necho \"$MOCK_TMUX_PANE_CMD\"\n").unwrap();
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script, perms).unwrap();
+            std::env::set_var("AM_TMUX_BIN", &script);
+            std::env::set_var("MOCK_TMUX_PANE_CMD", current);
+            Self {
+                _guard: guard,
+                _tmp: tmp,
+            }
+        }
+
+        fn failing() -> Self {
+            let guard = PANE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let tmp = tempfile::TempDir::new().unwrap();
+            let script = tmp.path().join("mock_tmux_fail");
+            std::fs::write(&script, "#!/bin/sh\nexit 1\n").unwrap();
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script, perms).unwrap();
+            std::env::set_var("AM_TMUX_BIN", &script);
+            Self {
+                _guard: guard,
+                _tmp: tmp,
+            }
+        }
+    }
+
+    impl Drop for MockPaneCmd {
+        fn drop(&mut self) {
+            std::env::remove_var("AM_TMUX_BIN");
+            std::env::remove_var("MOCK_TMUX_PANE_CMD");
+        }
+    }
+
+    #[test]
+    fn is_shell_process_recognizes_common_shells() {
+        for name in ["bash", "zsh", "sh", "dash", "fish", "ksh", "tcsh", "csh"] {
+            assert!(is_shell_process(name), "{name} should read as a shell");
+        }
+    }
+
+    #[test]
+    fn is_shell_process_strips_the_login_shell_dash() {
+        assert!(is_shell_process("-bash"));
+    }
+
+    #[test]
+    fn is_shell_process_rejects_an_agent_name() {
+        assert!(!is_shell_process("claude"));
+        assert!(!is_shell_process("podman"));
+    }
+
+    #[test]
+    fn host_session_running_agent_reads_as_running() {
+        let _mock = MockPaneCmd::set("claude");
+        let mut s = attach_test_session("feat");
+        s.agent = Some("claude".to_string());
+        assert_eq!(agent_pane_status(&s), PaneStatus::Running);
+    }
+
+    #[test]
+    fn host_session_bare_shell_reads_as_idle() {
+        let _mock = MockPaneCmd::set("bash");
+        let mut s = attach_test_session("feat");
+        s.agent = Some("claude".to_string());
+        assert_eq!(agent_pane_status(&s), PaneStatus::Idle);
+    }
+
+    #[test]
+    fn host_session_unrecognized_process_reads_as_ambiguous() {
+        // A shim interpreter (node/python/...) rather than the agent's own name (OQ-6) —
+        // must bias toward "leave it alone", not "idle".
+        let _mock = MockPaneCmd::set("node");
+        let mut s = attach_test_session("feat");
+        s.agent = Some("claude".to_string());
+        assert_eq!(agent_pane_status(&s), PaneStatus::Ambiguous);
+    }
+
+    #[test]
+    fn host_session_with_no_recorded_agent_at_a_shell_reads_as_idle_but_relaunches_nothing() {
+        // Nothing is recorded to compare against, so this can never read as `Running`; a
+        // bare shell still reads as `Idle` (it is, after all, confidently a shell) — but
+        // `relaunch_into_existing_window` has nothing to launch either way when `s.agent`
+        // is `None`, so the net effect is the same no-op as `Ambiguous` would produce.
+        let _mock = MockPaneCmd::set("bash");
+        let s = attach_test_session("feat");
+        assert_eq!(agent_pane_status(&s), PaneStatus::Idle);
+    }
+
+    #[test]
+    fn host_session_with_no_recorded_agent_and_unrecognized_process_is_ambiguous() {
+        let _mock = MockPaneCmd::set("node");
+        let s = attach_test_session("feat");
+        assert_eq!(agent_pane_status(&s), PaneStatus::Ambiguous);
+    }
+
+    #[test]
+    fn container_session_running_reads_as_running() {
+        let _mock = MockPaneCmd::set("podman");
+        let mut s = attach_test_session("feat");
+        s.container = Some(SessionContainer::image_mode(
+            "podman".to_string(),
+            "img:latest".to_string(),
+        ));
+        assert_eq!(agent_pane_status(&s), PaneStatus::Running);
+    }
+
+    #[test]
+    fn container_session_bare_shell_reads_as_idle() {
+        // The container is PID 1 for its own runtime process; once that exits, the pane
+        // reverts to a shell — no agent-specific comparison needed for this case.
+        let _mock = MockPaneCmd::set("bash");
+        let mut s = attach_test_session("feat");
+        s.container = Some(SessionContainer::image_mode(
+            "podman".to_string(),
+            "img:latest".to_string(),
+        ));
+        assert_eq!(agent_pane_status(&s), PaneStatus::Idle);
+    }
+
+    #[test]
+    fn container_session_unrecognized_process_reads_as_ambiguous() {
+        let _mock = MockPaneCmd::set("weird-process");
+        let mut s = attach_test_session("feat");
+        s.container = Some(SessionContainer::image_mode(
+            "podman".to_string(),
+            "img:latest".to_string(),
+        ));
+        assert_eq!(agent_pane_status(&s), PaneStatus::Ambiguous);
+    }
+
+    #[test]
+    fn a_failed_tmux_query_is_ambiguous_not_idle() {
+        let _mock = MockPaneCmd::failing();
+        let mut s = attach_test_session("feat");
+        s.agent = Some("claude".to_string());
+        assert_eq!(agent_pane_status(&s), PaneStatus::Ambiguous);
+    }
+
+    // ── cmd_attach: resume wording and output messages ─────────────────────────
+
+    use super::{
+        attach_recreate_message, attach_relaunch_message, resume_will_apply, AttachLaunch,
+    };
+
+    #[test]
+    fn resume_will_apply_is_false_when_resume_not_requested() {
+        assert!(!resume_will_apply(Some(KnownAgent::Claude), false));
+    }
+
+    #[test]
+    fn resume_will_apply_is_false_without_a_known_agent() {
+        assert!(!resume_will_apply(None, true));
+    }
+
+    #[test]
+    fn resume_will_apply_is_true_for_a_known_agent_when_requested() {
+        assert!(resume_will_apply(Some(KnownAgent::Claude), true));
+    }
+
+    #[test]
+    fn attach_recreate_message_variants() {
+        assert_eq!(
+            attach_recreate_message("feat", &AttachLaunch::NoAgentKnown),
+            "Opened new window for session 'feat'."
+        );
+        assert_eq!(
+            attach_recreate_message(
+                "feat",
+                &AttachLaunch::Agent {
+                    name: "claude".to_string(),
+                    resumed: false
+                }
+            ),
+            "Opened new window for session 'feat' and relaunched 'claude'."
+        );
+        assert_eq!(
+            attach_recreate_message(
+                "feat",
+                &AttachLaunch::Agent {
+                    name: "claude".to_string(),
+                    resumed: true
+                }
+            ),
+            "Opened new window for session 'feat' and relaunched 'claude' (resuming)."
+        );
+        assert_eq!(
+            attach_recreate_message("feat", &AttachLaunch::Container),
+            "Opened new window for session 'feat' and restarted the container."
+        );
+    }
+
+    #[test]
+    fn attach_relaunch_message_variants() {
+        assert_eq!(
+            attach_relaunch_message(
+                "feat",
+                &AttachLaunch::Agent {
+                    name: "claude".to_string(),
+                    resumed: true
+                }
+            ),
+            "Attached to session 'feat'; agent had exited — relaunched 'claude' (resuming)."
+        );
+        assert_eq!(
+            attach_relaunch_message("feat", &AttachLaunch::Container),
+            "Attached to session 'feat'; container had exited — restarted it."
         );
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -117,6 +117,11 @@ pub struct Session {
     #[serde(flatten)]
     pub tmux: TmuxMetadata,
     pub container: Option<SessionContainer>,
+    /// The agent last launched into this session's agent pane (e.g. "claude"). Used by
+    /// `am attach` to relaunch the agent after a reboot or a killed window. `None` for
+    /// records written before this field existed, or for sessions started with no agent.
+    #[serde(default)]
+    pub agent: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -360,6 +365,7 @@ mod tests {
                 original_shell_dir: None,
             },
             container: None,
+            agent: None,
         }
     }
 
@@ -407,6 +413,54 @@ mod tests {
         assert_eq!(c.runtime, "podman");
         assert_eq!(c.container_id.as_deref(), Some("abc123"));
         assert_eq!(c.mode, ContainerMode::Image);
+    }
+
+    #[test]
+    fn agent_roundtrips_json() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let repo = tmp.path().join("repo");
+        let mut s = make_session_for_repo("feat", &repo);
+        s.agent = Some("claude".to_string());
+        add_session_global(s).unwrap();
+
+        let loaded = load_all_sessions().unwrap();
+        assert_eq!(loaded[0].agent.as_deref(), Some("claude"));
+    }
+
+    #[test]
+    fn legacy_record_without_agent_field_loads_as_none() {
+        // Sessions written before Session.agent existed have no "agent" key at all.
+        // #[serde(default)] must make that load as None rather than erroring.
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let _env = EnvGuard::save(&["XDG_STATE_HOME", "HOME"]);
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("XDG_STATE_HOME", tmp.path());
+
+        let sessions_path = tmp.path().join("am").join("sessions.json");
+        std::fs::create_dir_all(sessions_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &sessions_path,
+            r#"{"sessions":[{
+                "slug":"legacy",
+                "created_at":"2026-01-01T00:00:00Z",
+                "repo_root":"/repo",
+                "branch":"am/legacy",
+                "worktree_path":".am/worktrees/legacy",
+                "tmux_window":"am-legacy",
+                "agent_pane":"am-legacy.1",
+                "shell_pane":"am-legacy.0",
+                "container":null
+            }]}"#,
+        )
+        .unwrap();
+
+        let loaded = load_all_sessions().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].agent, None);
     }
 
     #[test]

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -163,6 +163,26 @@ pub fn get_pane_id(window_target: &str, index: usize) -> String {
     format!("{window_target}.{index}")
 }
 
+/// The name of the foreground process currently running in `pane_target`
+/// (`tmux display-message -p -t <target> '#{pane_current_command}'`).
+///
+/// Used by `am attach` to tell whether an agent (or, for a container session, the
+/// container runtime) is still running in a pane before deciding whether to relaunch
+/// anything into it — see the module doc on `cmd_attach` for the safety bias this feeds.
+pub fn pane_current_command(pane_target: &str) -> Result<String> {
+    let bin = tmux_bin()?;
+    run_tmux_output(
+        &bin,
+        &[
+            "display-message",
+            "-p",
+            "-t",
+            pane_target,
+            "#{pane_current_command}",
+        ],
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -174,9 +194,35 @@ mod tests {
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     /// Write a mock tmux script that appends its args to `$MOCK_TMUX_LOG`.
+    ///
+    /// `new-window` returns a fixed window ID, matching real tmux's `-P -F '#{window_id}'`
+    /// output. `display-message` (used by `pane_current_command`) echoes `$MOCK_TMUX_PANE_CMD`,
+    /// defaulting to `bash`, so tests can simulate whatever the pane's foreground process is
+    /// without a real tmux server.
     fn make_mock_tmux(dir: &Path) -> std::path::PathBuf {
         let script = dir.join("mock_tmux");
-        std::fs::write(&script, "#!/bin/sh\necho \"$*\" >> \"$MOCK_TMUX_LOG\"\nif [ \"$1\" = \"new-window\" ]; then echo '@1'; fi\n").unwrap();
+        std::fs::write(
+            &script,
+            "#!/bin/sh\n\
+             echo \"$*\" >> \"$MOCK_TMUX_LOG\"\n\
+             if [ \"$1\" = \"new-window\" ]; then echo '@1'; fi\n\
+             if [ \"$1\" = \"display-message\" ]; then echo \"${MOCK_TMUX_PANE_CMD:-bash}\"; fi\n",
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+        script
+    }
+
+    /// Write a mock tmux script that always fails, to exercise error paths.
+    fn make_failing_mock_tmux(dir: &Path) -> std::path::PathBuf {
+        let script = dir.join("mock_tmux_fail");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\necho \"tmux: no such pane\" >&2\nexit 1\n",
+        )
+        .unwrap();
         let mut perms = std::fs::metadata(&script).unwrap().permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(&script, perms).unwrap();
@@ -432,5 +478,48 @@ mod tests {
         assert!(out.contains("-t"));
         assert!(out.contains("am-feat"));
         assert!(out.contains("old-name"));
+    }
+
+    // ── pane_current_command ─────────────────────────────────────────────────
+
+    #[test]
+    fn pane_current_command_sends_correct_command() {
+        let mock = MockTmux::new();
+        pane_current_command("am-feat.1").unwrap();
+        let out = mock.captured();
+        assert!(out.contains("display-message"));
+        assert!(out.contains("-p"));
+        assert!(out.contains("-t"));
+        assert!(out.contains("am-feat.1"));
+        assert!(out.contains("#{pane_current_command}"));
+    }
+
+    #[test]
+    fn pane_current_command_returns_the_process_name() {
+        let _mock = MockTmux::new();
+        std::env::set_var("MOCK_TMUX_PANE_CMD", "claude");
+        let result = pane_current_command("am-feat.1").unwrap();
+        std::env::remove_var("MOCK_TMUX_PANE_CMD");
+        assert_eq!(result, "claude");
+    }
+
+    #[test]
+    fn pane_current_command_defaults_to_a_shell_in_the_mock() {
+        let _mock = MockTmux::new();
+        let result = pane_current_command("am-feat.1").unwrap();
+        assert_eq!(result, "bash");
+    }
+
+    #[test]
+    fn pane_current_command_propagates_tmux_failure() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let bin = make_failing_mock_tmux(tmp.path());
+        std::env::set_var("AM_TMUX_BIN", &bin);
+
+        let err = pane_current_command("am-gone.1").unwrap_err();
+        std::env::remove_var("AM_TMUX_BIN");
+
+        assert!(err.to_string().contains("no such pane"));
     }
 }

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -153,6 +153,11 @@ impl AmWorld {
     }
 
     /// Install a mock tmux binary that logs every invocation to a file.
+    ///
+    /// `display-message` (used by `tmux::pane_current_command`, OQ-6) echoes
+    /// `$MOCK_TMUX_PANE_CMD`, defaulting to `bash`, so a scenario can simulate whatever the
+    /// agent pane's foreground process is — see `given_pane_reports` — without a real tmux
+    /// server. The same protocol as the private mock in `src/tmux.rs`'s own unit tests.
     fn setup_mock_tmux(&mut self) {
         let bin = self.project_dir.path().join("mock_tmux");
         let log = self.project_dir.path().join("mock_tmux.log");
@@ -164,6 +169,9 @@ impl AmWorld {
              fi\n\
              if [ \"$1\" = \"new-window\" ]; then\n\
                  echo \"@1\"\n\
+             fi\n\
+             if [ \"$1\" = \"display-message\" ]; then\n\
+                 echo \"${MOCK_TMUX_PANE_CMD:-bash}\"\n\
              fi\n\
              exit 0\n",
         )
@@ -177,6 +185,11 @@ impl AmWorld {
     /// Install a mock tmux that fails the **first** `select-window` call and
     /// succeeds on all subsequent calls. Used to exercise the window
     /// re-creation path in `am attach`.
+    ///
+    /// Also answers `display-message` (see `setup_mock_tmux`'s doc) — used by scenarios that
+    /// combine "window gone" with a specific recorded `Session.agent`/container runtime,
+    /// even though the OQ-6 fast path is never reached once the window has to be recreated;
+    /// kept consistent so every scenario can rely on the same mock protocol.
     fn setup_mock_tmux_failing_select_window(&mut self) {
         let bin = self.project_dir.path().join("mock_tmux");
         let log = self.project_dir.path().join("mock_tmux.log");
@@ -197,11 +210,78 @@ impl AmWorld {
                  if [ \"$1\" = \"new-window\" ]; then\n\
                      echo \"@1\"\n\
                  fi\n\
+                 if [ \"$1\" = \"display-message\" ]; then\n\
+                     echo \"${{MOCK_TMUX_PANE_CMD:-bash}}\"\n\
+                 fi\n\
                  if [ \"$1\" = \"select-window\" ] && [ ! -f \"{flag_str}\" ]; then\n\
                      touch \"{flag_str}\"\n\
                      exit 1\n\
                  fi\n\
                  exit 0\n"
+            ),
+        )
+        .expect("write mock_tmux");
+        #[cfg(unix)]
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).expect("chmod mock_tmux");
+        self.mock_tmux_bin = Some(bin);
+        self.mock_tmux_log = Some(log);
+    }
+
+    /// Install a mock tmux where the *original* window (`@1`, the first `new-window` call in
+    /// any scenario using this mock — deterministic, since every scenario starts a fresh mock
+    /// with its own counter at 0) is permanently gone, simulating a reboot precisely: unlike
+    /// `setup_mock_tmux_failing_select_window`'s "fail the first `select-window` call, then
+    /// always succeed" approximation — which can't tell a genuinely-reused window apart from a
+    /// stale target that coincidentally works again — this mock tracks every window actually
+    /// created via `new-window` and only lets `select-window` succeed against one of those,
+    /// with `@1` permanently excluded. So a retry against a *stale, unpersisted* window target
+    /// still fails, while a retry against a freshly created and properly persisted one
+    /// succeeds — the exact distinction "a preflight failure must leave the session record
+    /// pointing at real panes" needs to prove anything.
+    fn setup_mock_tmux_original_window_gone_forever(&mut self) {
+        let bin = self.project_dir.path().join("mock_tmux");
+        let log = self.project_dir.path().join("mock_tmux.log");
+        let counter = self.project_dir.path().join("mock_tmux_window_counter");
+        let created = self.project_dir.path().join("mock_tmux_created_windows");
+        // Seeded at 1, not 0: this mock replaces whichever plain mock created the session's
+        // *original* window (during the "a session ... has been started" setup step, before
+        // this step runs) — that call already claimed `@1`. Starting this counter at 0 would
+        // hand the very next `new-window` call (the recreate this scenario exists to test)
+        // that same `@1`, silently colliding with the id this mock hardcodes as permanently
+        // gone and making every retry fail regardless of whether `am attach` persisted the
+        // right target.
+        fs::write(&counter, "1").expect("seed mock_tmux window counter");
+        fs::write(
+            &bin,
+            format!(
+                "#!/bin/sh\n\
+                 if [ -n \"$MOCK_TMUX_LOG\" ]; then\n\
+                     echo \"$@\" >> \"$MOCK_TMUX_LOG\"\n\
+                 fi\n\
+                 if [ \"$1\" = \"new-window\" ]; then\n\
+                     n=$(( $(cat \"{counter}\" 2>/dev/null || echo 0) + 1 ))\n\
+                     echo \"$n\" > \"{counter}\"\n\
+                     echo \"@$n\" >> \"{created}\"\n\
+                     echo \"@$n\"\n\
+                     exit 0\n\
+                 fi\n\
+                 if [ \"$1\" = \"display-message\" ]; then\n\
+                     echo \"${{MOCK_TMUX_PANE_CMD:-bash}}\"\n\
+                     exit 0\n\
+                 fi\n\
+                 if [ \"$1\" = \"select-window\" ]; then\n\
+                     target=\"$3\"\n\
+                     if [ \"$target\" = \"@1\" ]; then\n\
+                         exit 1\n\
+                     fi\n\
+                     if [ -f \"{created}\" ] && grep -qxF \"$target\" \"{created}\"; then\n\
+                         exit 0\n\
+                     fi\n\
+                     exit 1\n\
+                 fi\n\
+                 exit 0\n",
+                counter = counter.to_string_lossy(),
+                created = created.to_string_lossy(),
             ),
         )
         .expect("write mock_tmux");
@@ -613,6 +693,21 @@ async fn given_session_started(world: &mut AmWorld, slug: String) {
     );
 }
 
+/// Like "a session {string} has been started", but records `Session.agent` at start time —
+/// the precondition most `am attach` relaunch scenarios need (a reboot recovers *something*
+/// only if something was recorded to recover).
+#[given(expr = "a session {string} has been started with agent {string}")]
+async fn given_session_started_with_agent(world: &mut AmWorld, slug: String, agent: String) {
+    world.run_am(&["start", &slug, "--agent", &agent]);
+    let output = world.last_output();
+    assert!(
+        output.status.success(),
+        "setup step 'am start {slug} --agent {agent}' failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
 #[given("I am inside a tmux session")]
 async fn given_in_tmux(world: &mut AmWorld) {
     world.setup_mock_tmux();
@@ -621,6 +716,59 @@ async fn given_in_tmux(world: &mut AmWorld) {
 #[given("the tmux window no longer exists")]
 async fn given_tmux_window_gone(world: &mut AmWorld) {
     world.setup_mock_tmux_failing_select_window();
+}
+
+#[given("the original tmux window is gone forever")]
+async fn given_tmux_original_window_gone_forever(world: &mut AmWorld) {
+    world.setup_mock_tmux_original_window_gone_forever();
+}
+
+/// Truncates the mock tmux log. Several `am attach` scenarios assert the *absence* of a
+/// command (no `new-window`, no `send-keys`) to prove the fast/no-op path took no tmux
+/// action — but the log accumulates across every `am` invocation in the scenario, including
+/// a setup step's own "a session ... has been started", which already logged its own
+/// `new-window`/`send-keys` calls. Without clearing first, that setup noise is what an
+/// absence check would actually be looking at, making it pass or fail for the wrong reason
+/// regardless of what the command under test did.
+#[given("I clear the mock tmux log")]
+async fn given_clear_tmux_log(world: &mut AmWorld) {
+    let log = world
+        .mock_tmux_log
+        .as_ref()
+        .expect("mock tmux was not set up for this scenario");
+    fs::write(log, "").expect("truncate mock tmux log");
+}
+
+/// Drives OQ-6's `pane_current_command` query (`agent_pane_status`) by making the mock
+/// tmux's `display-message` responder echo a specific value instead of its `bash` default —
+/// simulates the agent pane's foreground process being the recorded agent/container runtime
+/// (UC-3, "running"), a bare shell (UC-4, "idle"), or anything else (ambiguous).
+#[given(expr = "the agent pane reports {string} as its current command")]
+async fn given_pane_reports(world: &mut AmWorld, cmd: String) {
+    world.extra_env.push(("MOCK_TMUX_PANE_CMD".to_string(), cmd));
+}
+
+/// Simulates a session record written before `Session.agent` existed: strips the `agent` key
+/// out of the persisted JSON entirely (not merely setting it to `null`), the same shape a
+/// pre-feature `sessions.json` has on disk. `#[serde(default)]` is what is supposed to make
+/// loading this still work — this step exists so a scenario can prove that against the real
+/// file, not just via the unit test alongside `legacy_records_without_repo_root_migrate_
+/// correctly`.
+#[given("the session file has no recorded agent")]
+async fn given_session_file_no_agent(world: &mut AmWorld) {
+    let path = world.global_sessions_path();
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|_| panic!("sessions.json not found at {path:?}"));
+    let mut value: serde_json::Value =
+        serde_json::from_str(&content).expect("sessions.json should be valid JSON");
+    if let Some(sessions) = value.get_mut("sessions").and_then(|v| v.as_array_mut()) {
+        for session in sessions {
+            if let Some(obj) = session.as_object_mut() {
+                obj.remove("agent");
+            }
+        }
+    }
+    fs::write(&path, serde_json::to_string_pretty(&value).unwrap()).expect("rewrite sessions.json");
 }
 
 #[given("I am using a mock container runtime")]

--- a/tests/features/attach_restore_agent.feature
+++ b/tests/features/attach_restore_agent.feature
@@ -1,0 +1,201 @@
+Feature: Restore the agent on `am attach`
+  A reboot survives at the worktree and session-record level, but tmux and the agent
+  process do not. `am attach` must recreate them, not just the window — see
+  specs/attach-restore-agent.md.
+
+  Background:
+    Given a git repository
+    And I am inside a tmux session
+
+  # ── UC-1: post-reboot recovery, host session ──────────────────────────────────
+
+  Scenario: attach relaunches the recorded agent into a recreated window, resuming by default
+    Given a session "my-feature" has been started with agent "claude"
+    And the tmux window no longer exists
+    When I run "am attach my-feature"
+    Then the command succeeds
+    And the output contains "Opened new window for session 'my-feature' and relaunched 'claude' (resuming)."
+    And the mock tmux log contains "claude --continue"
+
+  # ── UC-6: --fresh forces a clean conversation ─────────────────────────────────
+
+  Scenario: attach --fresh relaunches without asking the agent to resume
+    Given a session "my-feature" has been started with agent "claude"
+    And the tmux window no longer exists
+    When I run "am attach my-feature --fresh"
+    Then the command succeeds
+    # Deliberately checked as a substring ending right after the quote: the "(resuming)"
+    # variant of this same message would NOT contain this exact substring, since something
+    # else follows the agent name there. See CLAUDE.md's guidance on {string} captures and
+    # backslash escapes — neither side of this comparison needs one, so a plain contains
+    # check is safe here.
+    And the output contains "relaunched 'claude'."
+    And the mock tmux log does not contain "--continue"
+
+  Scenario: [attach].resume = false has the same effect as --fresh, without the flag
+    Given a project config containing "[attach]\nresume = false\n"
+    And a session "my-feature" has been started with agent "claude"
+    And the tmux window no longer exists
+    When I run "am attach my-feature"
+    Then the command succeeds
+    And the output contains "relaunched 'claude'."
+    And the mock tmux log does not contain "--continue"
+
+  # ── UC-2: post-reboot recovery, containerized session ─────────────────────────
+
+  Scenario: attach recreates a gone container and hands the run command to the new split
+    Given am init has been run
+    And I am using a mock container runtime
+    And a session "my-feature" has been started
+    And the tmux window no longer exists
+    And I clear the mock tmux log
+    When I run "am attach my-feature"
+    Then the command succeeds
+    And the output contains "Opened new window for session 'my-feature' and restarted the container."
+    # The window is split first, with no command (so the record's pane targets are valid
+    # even if what follows fails — see recreate_attach_window's doc comment), and the
+    # rebuilt "podman run ..." command line is then typed into the fresh agent pane via
+    # send-keys rather than exec'd as the split's own shell_cmd — so the proof lives in the
+    # tmux log's send-keys line, not the podman log. Mirrors "start with container records
+    # container metadata" in container.feature, which pins the analogous shape for `am
+    # start`, which — unlike attach — can exec the command at split time because its
+    # preflight always runs before it ever touches tmux.
+    And the mock tmux log contains "run"
+    And the mock tmux log contains "--name am-my-feature"
+    And the mock tmux log contains "test-image:latest"
+    And the mock tmux log contains "split-window"
+    And the mock tmux log contains "send-keys"
+
+  # A3: the window *and split* must already exist by the time a container preflight failure
+  # can occur ("the user is left with an opened window and a clear error"). recreate_attach_
+  # window creates the window and splits it (with no command) before attempting the
+  # container plan, and persists those pane targets immediately — so a preflight failure
+  # here leaves a real, addressable window+split behind, and a retry can make progress
+  # instead of silently no-op'ing forever against panes the record thinks exist but don't.
+  Scenario: attach reports a clear error when the container runtime disappears before recreate
+    Given am init has been run
+    And I am using a mock container runtime
+    And a session "my-feature" has been started
+    And the tmux window no longer exists
+    And I have set env "AM_PODMAN_BIN" to "/nonexistent/am-test-podman"
+    And I have set env "AM_DOCKER_BIN" to "/nonexistent/am-test-docker"
+    And I clear the mock tmux log
+    When I run "am attach my-feature"
+    Then the command fails
+    And the output does not contain "panicked"
+    And the mock tmux log contains "new-window"
+    And the mock tmux log contains "split-window"
+
+  # The actual point of the fix: a preflight failure must be *recoverable*, not a dead end.
+  # "I have set env ..." only applies to the one `run_am` invocation that follows it (see
+  # AmWorld::run_am, which drains extra_env after each call) — so this second attach runs
+  # with the working mock runtime restored, exactly as a user re-running `am attach` after
+  # fixing whatever broke (e.g. `podman machine start`) would.
+  #
+  # Uses the dedicated "gone forever" tmux mock, not "the tmux window no longer exists": that
+  # mock's fail-the-first-select-window-call-then-always-succeed approximation can't tell a
+  # genuinely reused window from a stale target that happens to work anyway, so it can't prove
+  # this property (confirmed: reverting the split-first ordering fix left this scenario green
+  # under that mock — see the stub-and-revert note below). This mock tracks real window
+  # identity: only a target actually created via `new-window` succeeds, and the original `@1`
+  # is excluded permanently — so a retry only reaches the fast "already exists, relaunch"
+  # path (and its distinct message) if the first attempt's window/split were genuinely
+  # created *and persisted* before it failed.
+  Scenario: a retry after a container preflight failure makes progress instead of looping
+    Given am init has been run
+    And I am using a mock container runtime
+    And a session "my-feature" has been started
+    And the original tmux window is gone forever
+    And I have set env "AM_PODMAN_BIN" to "/nonexistent/am-test-podman"
+    And I have set env "AM_DOCKER_BIN" to "/nonexistent/am-test-docker"
+    When I run "am attach my-feature"
+    Then the command fails
+    When I run "am attach my-feature"
+    Then the command succeeds
+    And the output contains "container had exited — restarted it."
+
+  # ── UC-3: fast no-op path when the pane is confidently alive ──────────────────
+
+  Scenario: attach stays a no-op when the agent pane is confidently running (host)
+    Given a session "my-feature" has been started with agent "claude"
+    And the agent pane reports "claude" as its current command
+    And I clear the mock tmux log
+    When I run "am attach my-feature"
+    Then the command succeeds
+    And the output contains "Attached to session 'my-feature'."
+    And the output does not contain "relaunched"
+    And the mock tmux log does not contain "send-keys"
+
+  Scenario: attach stays a no-op when the container is confidently running
+    Given am init has been run
+    And I am using a mock container runtime
+    And a session "my-feature" has been started
+    And the agent pane reports "podman" as its current command
+    And I clear the mock tmux log
+    When I run "am attach my-feature"
+    Then the command succeeds
+    And the output contains "Attached to session 'my-feature'."
+    And the output does not contain "restarted the container"
+    And the mock tmux log does not contain "send-keys"
+
+  # ── UC-4: live window, dead agent → relaunch in place ──────────────────────────
+
+  Scenario: attach relaunches into an existing window whose agent pane went idle
+    Given a session "my-feature" has been started with agent "claude"
+    And the agent pane reports "bash" as its current command
+    And I clear the mock tmux log
+    When I run "am attach my-feature"
+    Then the command succeeds
+    And the output contains "Attached to session 'my-feature'; agent had exited — relaunched 'claude' (resuming)."
+    And the mock tmux log contains "send-keys"
+    And the mock tmux log contains "claude --continue"
+    And the mock tmux log does not contain "new-window"
+
+  Scenario: attach restarts a container whose foreground process exited, into the same pane
+    Given am init has been run
+    And I am using a mock container runtime
+    And a session "my-feature" has been started
+    And the agent pane reports "bash" as its current command
+    And I clear the mock tmux log
+    When I run "am attach my-feature"
+    Then the command succeeds
+    And the output contains "Attached to session 'my-feature'; container had exited — restarted it."
+    And the mock tmux log contains "send-keys"
+    And the mock tmux log contains "run"
+    And the mock tmux log does not contain "new-window"
+
+  # ── UC-5: legacy session record (no agent ever recorded) ──────────────────────
+
+  Scenario: a legacy record with no agent known still attaches cleanly and points at `am run`
+    Given a session "my-feature" has been started
+    And the session file has no recorded agent
+    And the tmux window no longer exists
+    And I clear the mock tmux log
+    When I run "am attach my-feature"
+    Then the command succeeds
+    And the output contains "Opened new window for session 'my-feature'."
+    And the output contains "am attach does not know which agent to launch — run 'am run my-feature <agent>'"
+    And the mock tmux log does not contain "send-keys"
+
+  Scenario: a legacy record falls back to the configured agent and persists it
+    Given a session "my-feature" has been started
+    And the session file has no recorded agent
+    And a project config containing "[defaults]\nagent = \"claude\"\n"
+    And the tmux window no longer exists
+    When I run "am attach my-feature"
+    Then the command succeeds
+    And the output contains "relaunched 'claude' (resuming)."
+    And the session file contains "claude"
+
+  # ── Regression: `am run` supersedes what `am start` originally recorded ───────
+
+  Scenario: attach relaunches whatever `am run` most recently launched, not what `am start` recorded
+    Given a session "my-feature" has been started with agent "claude"
+    When I run "am run my-feature codex"
+    Then the command succeeds
+    Given the tmux window no longer exists
+    When I run "am attach my-feature"
+    Then the command succeeds
+    And the output contains "relaunched 'codex' (resuming)."
+    And the mock tmux log contains "codex resume --last"
+    And the output does not contain "relaunched 'claude'"

--- a/tests/features/tmux.feature
+++ b/tests/features/tmux.feature
@@ -44,15 +44,14 @@ Feature: am start and am attach with tmux
     And the mock tmux log contains "kill-window"
     And the mock tmux log contains "am-my-feature"
 
-  Scenario: attach to a container session with missing window suggests a clean restart
+  Scenario: attach to a container session with a missing window recreates the container
     Given am init has been run
     And I am using a mock container runtime
     And a session "my-feature" has been started
     And the tmux window no longer exists
     When I run "am attach my-feature"
     Then the command succeeds
-    And the output contains "  Note: the container was stopped when the window closed."
-    And the output contains "To restart cleanly: am destroy --force my-feature && am start my-feature"
+    And the output contains "Opened new window for session 'my-feature' and restarted the container."
 
   Scenario: attach's headline stays plain when its window is recreated
     Given a session "my-feature" has been started
@@ -63,7 +62,7 @@ Feature: am start and am attach with tmux
     Then the command succeeds
     And the output contains the plain line "Opened new window for session 'my-feature'."
 
-  Scenario: attach's restart note is colored like every other Note, and stays outside the dimmed hint under it
+  Scenario: attach's no-agent-known note is colored like every other Note
     Given am init has been run
     And I am using a mock container runtime
     And a session "my-feature" has been started
@@ -72,5 +71,5 @@ Feature: am start and am attach with tmux
     And I have set env "CLICOLOR_FORCE" to "1"
     When I run "am attach my-feature"
     Then the command succeeds
-    And the output contains the note line "the container was stopped when the window closed."
-    And the output contains the dimmed line "To restart cleanly: am destroy --force my-feature && am start my-feature"
+    And the output contains the plain line "Opened new window for session 'my-feature' and restarted the container."
+    And the output contains the note line "am attach does not know which agent to launch — run 'am run my-feature <agent>'"


### PR DESCRIPTION
## Problem

After a reboot, a session's worktree and record survive but tmux and the agent do not. `am attach` recreated an empty
window and launched nothing — `am` never recorded which agent a session was started with. Containerized sessions got a
note telling you to `am destroy --force && am start` by hand.

## What changed

`Session.agent` is now recorded by `am start` and kept current by `am run`, so attach knows what to relaunch. Attach
inspects the agent pane and does the least work needed:

- live session → unchanged instant no-op
- live window, idle agent pane → relaunch in place via `send-keys`
- gone window → recreate window, split, and (for containerized sessions) the container

Resume is on by default: `--continue` for Claude and Copilot, `--resume latest` for Gemini, `resume --last` for Codex —
each verified against the CLI's own `--help`. Opt out with `am attach --fresh` or `[attach].resume = false`.

Records written before this change fall back to `config.agent` and persist the resolved value; when neither is available,
attach says so and points at `am run`.

## Design notes

- Pane detection is biased toward doing nothing on any ambiguity. A missed relaunch costs an `am run`; relaunching over a
live agent can destroy in-flight work.
- The window and split are created and recorded *before* any container preflight runs. An earlier revision planned the
container first, which left a window with no split and a record pointing at panes that never existed — every subsequent
attach then read as ambiguous and silently no-opped forever. Covered by a regression scenario.
- Attach can now be as slow as `am start`, and fail the same ways, when a container is genuinely gone. Deliberate trade.

## Testing

528 unit tests + 120 cucumber scenarios (1031 steps), `cargo clippy --all-targets -- -D warnings` clean.

**Not yet exercised against a real reboot** — all coverage uses mocked tmux and mocked container runtimes. The
container-recreate branch in particular deserves a live test before this is relied on.

## Known gap (documented in BACKLOG.md, not fixed here)

Credential preflight checks that a credential *path* exists, not that the credential is valid. An expired token leaves
`~/.claude` in place, so preflight passes, attach reports `... and restarted the container.`, and exits `0` while the
agent fails to authenticate inside the pane. Pre-existing behavior inherited from `am start`; what's new is that attach
reaches it and asserts a recovery that may not have happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014i3TyRtAtmBqj5Bt6PKqo1