### PR TITLE
ci: support beta releases from a tag

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,10 @@ on:
       - '.github/workflows/docs.yml'
   push:
     tags:
+      # Stable tags only, deliberately. release.yml and images.yml also match prerelease tags
+      # (v1.2.3-beta.1); this one does not, because the published site has no notion of
+      # versions — deploying from a beta would replace the documentation for the release
+      # people are actually running.
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      # Prerelease tags publish images under their own version, but never move `latest`.
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
   workflow_dispatch:
     inputs:
       tag:
@@ -42,10 +44,19 @@ jobs:
         id: tag
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.tag }}" ]; then
-            echo "version=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            version="${{ inputs.tag }}"
           else
-            echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+            version="${GITHUB_REF_NAME}"
           fi
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+          # `latest` is what anyone pulling without a tag gets, including am's own default
+          # image names — so a prerelease must not claim it. The hyphen is semver's prerelease
+          # marker and the only thing distinguishing these tags.
+          case "$version" in
+            *-*) echo "latest=false" >> $GITHUB_OUTPUT ;;
+            *)   echo "latest=true"  >> $GITHUB_OUTPUT ;;
+          esac
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -61,7 +72,7 @@ jobs:
           images: ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}
           tags: |
             type=raw,value=${{ steps.tag.outputs.version }}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ steps.tag.outputs.latest }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,39 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      # The tag is the version. Everything downstream — the binary's own --version, the .deb
+      # and .rpm metadata, the archive names — reads Cargo.toml, so setting it here is what
+      # makes them all agree with the tag that triggered the build. Without this a beta cut
+      # from a branch whose version was not bumped ships artifacts named for the tag
+      # containing a binary that reports something else.
+      #
+      # Only the [package] version: dependency entries match `^version = ` too, and the
+      # package block is the first in the file. awk exits non-zero if it substituted nothing,
+      # so a change to Cargo.toml's shape fails the release rather than silently shipping the
+      # wrong version.
+      - name: Set the crate version from the tag
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v v="$version" '
+            /^\[/ { in_pkg = ($0 == "[package]") }
+            in_pkg && /^version = / && !done { print "version = \"" v "\""; done = 1; next }
+            { print }
+            END { if (!done) exit 1 }
+          ' Cargo.toml > Cargo.toml.tagged || {
+            echo "::error title=Version not set::no [package] version line found in Cargo.toml"
+            exit 1
+          }
+          mv Cargo.toml.tagged Cargo.toml
+
+          set=$(awk '/^\[/ { in_pkg = ($0 == "[package]") }
+                     in_pkg && /^version = / { print; exit }' Cargo.toml)
+          echo "Cargo.toml now says: $set"
+          [ "$set" = "version = \"$version\"" ] || {
+            echo "::error title=Version not set::expected version = \"$version\", got $set"
+            exit 1
+          }
+
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 
@@ -143,14 +176,14 @@ jobs:
             *)   echo "prerelease=false" >> $GITHUB_OUTPUT ;;
           esac
 
-          # The packages take their version from Cargo.toml, not from the tag, so the two
-          # disagreeing produces artifacts whose name and contents differ. Warned rather than
-          # enforced: a prerelease cut from a branch before the version bump is a legitimate
-          # thing to do, and failing here would block exactly that.
+          # The build job rewrites Cargo.toml from the tag, so the artifacts and the binary
+          # both report $version whatever this ref happens to say. A difference is worth
+          # noting — the repository should be bumped so local builds agree — but it is not a
+          # problem with the release, so it is a notice rather than a warning.
           crate=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
           if [ "$crate" != "$version" ]; then
-            echo "::warning title=Version skew::tag says $version, Cargo.toml says $crate —" \
-                 "the binary will report $crate"
+            echo "::notice title=Version::released as $version from the tag; Cargo.toml on" \
+                 "this ref says $crate — bump it so local builds match"
           fi
 
       - name: Download all artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      # Prerelease tags: v1.2.3-beta.1, v1.2.3-rc.2. Everything downstream keys off the
+      # hyphen — the release is marked as a prerelease and the Homebrew tap is left alone,
+      # so `brew upgrade` users never see one.
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
   build:
@@ -123,12 +127,31 @@ jobs:
       contents: write
     outputs:
       version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v7
 
       - name: Get version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          echo "version=$version" >> $GITHUB_OUTPUT
+          # A hyphen is what semver uses to mark a prerelease, and it is the only thing that
+          # distinguishes these tags from a normal one.
+          case "$version" in
+            *-*) echo "prerelease=true" >> $GITHUB_OUTPUT ;;
+            *)   echo "prerelease=false" >> $GITHUB_OUTPUT ;;
+          esac
+
+          # The packages take their version from Cargo.toml, not from the tag, so the two
+          # disagreeing produces artifacts whose name and contents differ. Warned rather than
+          # enforced: a prerelease cut from a branch before the version bump is a legitimate
+          # thing to do, and failing here would block exactly that.
+          crate=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          if [ "$crate" != "$version" ]; then
+            echo "::warning title=Version skew::tag says $version, Cargo.toml says $crate —" \
+                 "the binary will report $crate"
+          fi
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -170,15 +193,35 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          NOTES: ${{ steps.notes.outputs.NOTES }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "Release ${{ github.ref_name }}" \
-            --notes "${{ steps.notes.outputs.NOTES }}" \
-            release-files/*
+          args=(--title "Release ${{ github.ref_name }}")
+
+          # A prerelease usually has no CHANGELOG section yet — the entry lands when the final
+          # version ships. Rather than publish an empty release, or worse the *previous*
+          # version's notes, fall back to the commit list GitHub can generate.
+          if [ -n "${NOTES//[[:space:]]/}" ]; then
+            args+=(--notes "$NOTES")
+          else
+            echo "no CHANGELOG section for this version; generating notes from commits"
+            args+=(--generate-notes)
+          fi
+
+          # Marks it as a prerelease, which keeps it off the repository's front page as
+          # "Latest" and out of anything resolving the newest stable version.
+          if [ "$PRERELEASE" = "true" ]; then
+            args+=(--prerelease)
+          fi
+
+          gh release create "${{ github.ref_name }}" "${args[@]}" release-files/*
 
   homebrew:
     name: Update Homebrew Tap
     needs: release
+    # A prerelease must not reach the tap: the formula is what every `brew upgrade` follows,
+    # so publishing a beta there ships it to people who never asked for one.
+    if: needs.release.outputs.prerelease != 'true'
     runs-on: ubuntu-latest
     env:
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/docs/reference/building.md
+++ b/docs/reference/building.md
@@ -113,7 +113,13 @@ has none — the entry lands when the final version ships. When that section is 
 workflow falls back to notes generated from the commit range instead of publishing an empty
 release.
 
-The version in the artifacts comes from the *tag*, but the version compiled into the binary
-and into the `.deb`/`.rpm` metadata comes from `Cargo.toml`. Tagging a prerelease from a branch
-whose `Cargo.toml` has not been bumped is legitimate, so the workflow warns about the mismatch
-rather than failing — but `am --version` will report the crate's version, not the tag's.
+The tag is the version. Before building, the release workflow rewrites `[package] version` in
+`Cargo.toml` from the tag, so the archive names, the `.deb`/`.rpm` metadata and `am --version`
+all agree with the tag that triggered the build — including for a prerelease cut from a branch
+whose `Cargo.toml` has not been bumped. Only the `[package]` entry is touched; if that line
+cannot be found the release fails rather than shipping artifacts labelled one version and
+containing another.
+
+The rewrite is confined to the build. `Cargo.toml` in the repository is not updated by it, so
+bump it separately when a release lands or local builds will keep reporting the older number —
+the workflow emits a notice when the two differ.

--- a/docs/reference/building.md
+++ b/docs/reference/building.md
@@ -91,3 +91,29 @@ Two workflows exercise the build:
   above (Linux via `ubuntu-latest`/`ubuntu-24.04-arm`, macOS via
   `macos-latest`, Windows via `windows-latest`), then packages the artifacts
   and publishes them to the GitHub release.
+
+### Prereleases
+
+A tag carrying a semver prerelease suffix — `v1.2.3-beta.1`, `v1.2.3-rc.2` — builds and
+publishes the same artifacts, with three differences that keep it away from people who did not
+ask for it:
+
+| | Stable tag | Prerelease tag |
+|---|---|---|
+| GitHub release | normal, shown as "Latest" | marked prerelease |
+| Homebrew tap | formula updated | **not touched** |
+| Container images | pushed, `latest` moved | pushed, `latest` left alone |
+| Documentation site | republished | **not republished** |
+
+The Homebrew and `latest` exclusions are the ones that matter: both are what a user gets when
+they ask for no version in particular, so a beta reaching either ships it to everyone.
+
+Release notes come from the first `## [` section of `CHANGELOG.md`, and a prerelease usually
+has none — the entry lands when the final version ships. When that section is empty the
+workflow falls back to notes generated from the commit range instead of publishing an empty
+release.
+
+The version in the artifacts comes from the *tag*, but the version compiled into the binary
+and into the `.deb`/`.rpm` metadata comes from `Cargo.toml`. Tagging a prerelease from a branch
+whose `Cargo.toml` has not been bumped is legitimate, so the workflow warns about the mismatch
+rather than failing — but `am --version` will report the crate's version, not the tag's.


### PR DESCRIPTION
Prerelease tags (v1.2.3-beta.1) now build and publish, with everything that would reach someone who did not ask
for a beta switched off: the GitHub release is marked prerelease, the Homebrew tap is not updated, container `latest`
is not moved, and the docs site is not republished. The build also derives the crate version from the tag, so archive
names, .deb/.rpm metadata and `am --version` all agree with it.